### PR TITLE
Handle missing dotenv dependency

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,4 +1,9 @@
-require('dotenv').config();
+try {
+  require('dotenv').config();
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') throw err;
+  process.emitWarning('dotenv package not found; skipping .env file loading.');
+}
 const express = require('express');
 const helmet = require('helmet');
 const cors = require('cors');


### PR DESCRIPTION
## Summary
- guard the dotenv import so the server can start even when the package is not installed

## Testing
- not run (requires external services)


------
https://chatgpt.com/codex/tasks/task_e_68cab410cce08326b85957ef201e1b55