### PR TITLE
Allow external avatar images in CSP

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,7 +17,19 @@ const app = express();
 connectDB();
 
 // security & parsers
-app.use(helmet());
+const defaultCsp = helmet.contentSecurityPolicy.getDefaultDirectives();
+const extendedCsp = {
+  ...defaultCsp,
+  'img-src': [...(defaultCsp['img-src'] || []), 'https://i.pravatar.cc'],
+};
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: extendedCsp,
+    },
+  })
+);
 app.use(express.json({ limit: '100kb' }));
 app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 app.use(mongoSanitize());


### PR DESCRIPTION
## Summary
- configure Helmet's content security policy to permit loading avatar images from https://i.pravatar.cc

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cad57b63c88326aae599b253ebabb0