### PR TITLE
Add admin seeding script and align user model

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -1,3 +1,7 @@
 PORT=4000
 NODE_ENV=development
-MONGO_URI=mongodb://127.0.0.1:27017/iquiz
+MONGO_URI=mongodb://localhost:27017/iquiz
+
+# Admin seed
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=ChangeThis!123

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,9 @@
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {
+    "start": "node src/index.js",
     "dev": "node src/index.js",
-    "seed:admin": "node src/seed/seedAdmin.js"
+    "seed:admin": "node src/seed/createAdmin.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -5,18 +5,28 @@ const { isEmail } = require('validator');
 const userSchema = new mongoose.Schema(
   {
     username: { type: String, required: true, trim: true },
+    name:     { type: String, trim: true, default: function () { return this.username; } },
     email:    { type: String, required: true, unique: true, lowercase: true, validate: [isEmail, 'Invalid email'] },
     password: { type: String, required: true, minlength: 6, select: false },
     role:     { type: String, enum: ['user', 'vip', 'admin'], default: 'user' },
     coins:    { type: Number, default: 0 },
     score:    { type: Number, default: 0 },
-    status:   { type: String, enum: ['active', 'blocked', 'pending'], default: 'active' }
+    status:   { type: String, enum: ['active', 'blocked', 'pending'], default: 'active' },
+    isActive: { type: Boolean, default: true }
   },
   { timestamps: true }
 );
 
 userSchema.pre('save', async function (next) {
   if (!this.isModified('password')) return next();
+
+  try {
+    bcrypt.getRounds(this.password);
+    return next();
+  } catch (err) {
+    // Password is not hashed yet; continue to hash below.
+  }
+
   const salt = await bcrypt.genSalt(10);
   this.password = await bcrypt.hash(this.password, salt);
   next();

--- a/server/src/seed/createAdmin.js
+++ b/server/src/seed/createAdmin.js
@@ -1,0 +1,45 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+// ✅ مسیر مدل کاربر را با پروژه‌ی من هماهنگ کن (در صورت تفاوت تغییر بده)
+const User = require('../models/User');
+// مثال‌های احتمالی دیگر:
+// const User = require('../models/users.model');
+// const User = require('../models/User');
+
+(async () => {
+  try {
+    const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/iquiz';
+    await mongoose.connect(mongoUri, {});
+
+    const email = process.env.ADMIN_EMAIL || 'admin@example.com';
+    const plain = process.env.ADMIN_PASSWORD || 'ChangeThis!123';
+
+    let user = await User.findOne({ email });
+    if (user) {
+      console.log('✅ Admin already exists:', email);
+      process.exit(0);
+    }
+
+    const hash = await bcrypt.hash(plain, 12);
+
+    // ⚠️ اگر مدل/فیلدها متفاوت است، این آبجکت را با مدل من هماهنگ کن
+    user = await User.create({
+      username: 'System Admin',
+      name: 'System Admin',
+      email,
+      password: hash,
+      role: 'admin',
+      status: 'active',
+      isActive: true
+    });
+
+    console.log('✅ Admin created:', email);
+    console.log('🔐 Password:', plain);
+    process.exit(0);
+  } catch (err) {
+    console.error('❌ Failed to create admin:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add an admin seeding script that hashes credentials and reuses project user model fields
- expose admin seed environment variables in the sample .env and wire up npm scripts
- extend the user model with name/isActive fields while preventing double-hashing of pre-hashed passwords

## Testing
- npm run seed:admin *(fails: requires a running MongoDB instance)*

------
https://chatgpt.com/codex/tasks/task_e_68caf6b062ac83269adacc1e82be5f79