### PR TITLE
Handle missing JWT secret with development fallback

### DIFF
--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -1,0 +1,19 @@
+const logger = require('./logger');
+
+const env = {
+  nodeEnv: process.env.NODE_ENV || 'development',
+  jwt: {
+    secret: process.env.JWT_SECRET,
+    expiresIn: process.env.JWT_EXPIRES_IN || '7d'
+  }
+};
+
+if (!env.jwt.secret) {
+  if (env.nodeEnv === 'production') {
+    throw new Error('JWT_SECRET environment variable is required in production');
+  }
+  env.jwt.secret = 'development-only-jwt-secret-change-me';
+  logger.warn('JWT_SECRET environment variable is not set. Using an insecure fallback secret for development.');
+}
+
+module.exports = Object.freeze(env);

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,7 +1,8 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const { jwt: jwtConfig } = require('../config/env');
 
-const sign = (id) => jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRES_IN || '7d' });
+const sign = (id) => jwt.sign({ id }, jwtConfig.secret, { expiresIn: jwtConfig.expiresIn });
 
 exports.login = async (req, res, next) => {
   try {

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const { jwt: jwtConfig } = require('../config/env');
 
 exports.protect = async (req, res, next) => {
   try {
@@ -7,7 +8,7 @@ exports.protect = async (req, res, next) => {
     const token = auth.startsWith('Bearer ') ? auth.split(' ')[1] : null;
     if (!token) return res.status(401).json({ ok:false, message:'Unauthorized' });
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, jwtConfig.secret);
     const user = await User.findById(decoded.id).select('+password');
     if (!user) return res.status(401).json({ ok:false, message:'User not found' });
     req.user = user;


### PR DESCRIPTION
## Summary
- add a shared environment config that provides JWT defaults and logs a warning when the secret is missing outside production
- update the auth controller and auth middleware to read the JWT secret and expiration from the centralized configuration

## Testing
- node - <<'NODE'
process.env.NODE_ENV = 'development';
const { jwt: jwtConfig } = require('./src/config/env');
const jwt = require('jsonwebtoken');
const token = jwt.sign({ id: '123' }, jwtConfig.secret, { expiresIn: jwtConfig.expiresIn });
console.log('token length', token.length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cafaca34788326b1bd736e629e77ae