### PR TITLE
Add trivia import API

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "morgan": "^1.10.1",
+        "node-fetch": "^2.6.7",
         "validator": "^13.11.0",
         "winston": "^3.13.0",
         "xss-clean": "^0.1.4"

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
     "morgan": "^1.10.1",
+    "node-fetch": "^2.6.7",
     "validator": "^13.11.0",
     "winston": "^3.13.0",
     "xss-clean": "^0.1.4"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,6 +13,7 @@ const morgan = require('morgan');
 const connectDB = require('./config/db');
 const logger = require('./config/logger');
 const errorHandler = require('./middleware/error');
+const triviaRoutes = require('./routes/trivia');
 
 // init
 const app = express();
@@ -85,6 +86,7 @@ app.use('/api/categories', require('./routes/categories.routes'));
 app.use('/api/questions', require('./routes/questions.routes'));
 app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/achievements', require('./routes/achievements.routes'));
+app.use('/api/trivia', triviaRoutes);
 
 // error handler
 app.use(errorHandler);

--- a/server/src/models/Question.js
+++ b/server/src/models/Question.js
@@ -2,14 +2,29 @@ const mongoose = require('mongoose');
 
 const questionSchema = new mongoose.Schema(
   {
-    text:       { type: String, required: true, trim: true },
-    options:    { type: [String], validate: v => v.length === 4, required: true }, // 4 گزینه
-    correctIdx: { type: Number, min: 0, max: 3, required: true },
+    text: { type: String, required: true, trim: true },
+    choices: {
+      type: [String],
+      required: true,
+      alias: 'options',
+      validate: {
+        validator: v => Array.isArray(v) && v.length === 4,
+        message: 'choices must be an array of 4 strings'
+      }
+    },
+    correctIndex: {
+      type: Number,
+      min: 0,
+      max: 3,
+      required: true,
+      alias: 'correctIdx'
+    },
     difficulty: { type: String, enum: ['easy', 'medium', 'hard'], default: 'easy' },
-    category:   { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
-    active:     { type: Boolean, default: true }
+    category: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
+    categoryName: { type: String, trim: true },
+    active: { type: Boolean, default: true }
   },
-  { timestamps: true }
+  { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } }
 );
 
 module.exports = mongoose.model('Question', questionSchema);

--- a/server/src/routes/trivia.js
+++ b/server/src/routes/trivia.js
@@ -1,0 +1,76 @@
+const router = require('express').Router();
+
+let fetchImpl = globalThis.fetch;
+try {
+  // node-fetch@2 (CommonJS) - preferred per requirements
+  fetchImpl = require('node-fetch');
+} catch (err) {
+  if (typeof fetchImpl !== 'function') throw err;
+}
+const Question = require('../models/Question');
+const Category = require('../models/Category');
+
+const TRIVIA_URL = 'https://opentdb.com/api.php?amount=20&type=multiple';
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+router.post('/import', async (req, res, next) => {
+  try {
+    const response = await fetchImpl(TRIVIA_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch trivia questions: ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (payload.response_code && payload.response_code !== 0) {
+      return res.status(502).json({ ok: false, message: 'Trivia provider returned an error' });
+    }
+
+    const questions = Array.isArray(payload.results) ? payload.results : [];
+    if (questions.length === 0) {
+      return res.status(502).json({ ok: false, message: 'No trivia questions returned from provider' });
+    }
+
+    const categoryCache = new Map();
+    const docs = [];
+
+    for (const item of questions) {
+      const incorrect = Array.isArray(item.incorrect_answers) ? item.incorrect_answers : [];
+      const correct = item.correct_answer;
+      const choices = shuffle([...incorrect, correct]);
+      const correctIndex = choices.indexOf(correct);
+
+      const categoryName = item.category || 'General';
+      let categoryDoc = categoryCache.get(categoryName);
+      if (!categoryDoc) {
+        categoryDoc = await Category.findOne({ name: categoryName });
+        if (!categoryDoc) {
+          categoryDoc = await Category.create({ name: categoryName });
+        }
+        categoryCache.set(categoryName, categoryDoc);
+      }
+
+      docs.push({
+        text: item.question,
+        choices,
+        correctIndex,
+        difficulty: item.difficulty || 'easy',
+        category: categoryDoc._id,
+        categoryName
+      });
+    }
+
+    const inserted = await Question.insertMany(docs);
+    res.json({ ok: true, count: inserted.length });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add a `/api/trivia/import` route that fetches OpenTDB questions, shuffles answers and stores them along with categories
- expand the Question schema with `choices`/`correctIndex` aliases and keep the fetched category name
- register the trivia routes with Express and declare the node-fetch dependency

## Testing
- `node -e "const router = require('./server/src/routes/trivia'); console.log(typeof router);"`
- `npm install node-fetch@2` *(fails in this environment: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68caff056a34832683b51bb5a3f4a4fa