### PR TITLE
Fix admin icons blocked by CSP

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -46,8 +46,33 @@
       -webkit-backdrop-filter: blur(20px); 
       border: 1px solid rgba(255,255,255,0.1);
     }
-    .btn{ 
-      @apply w-full py-3 rounded-xl font-bold shadow-lg active:scale-[0.98] transition-all duration-300 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900;
+    .btn{
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border-radius: 0.75rem;
+      font-weight: 700;
+      box-shadow: 0 12px 30px -12px rgba(15, 23, 42, 0.65);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      text-align: center;
+      outline: none;
+      border: none;
+      cursor: pointer;
+      transform: translateZ(0);
+    }
+    .btn:hover{
+      transform: scale(1.02);
+      box-shadow: 0 16px 40px -18px rgba(15, 23, 42, 0.75);
+    }
+    .btn:active{
+      transform: scale(0.98);
+    }
+    .btn:focus{
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25), 0 0 0 6px rgba(15, 23, 42, 0.6);
     }
     .btn-primary{ 
       background: linear-gradient(135deg, var(--accent1), var(--accent2)); 
@@ -65,8 +90,11 @@
       box-shadow: 0 4px 15px rgba(99, 102, 241, 0.4);
     }
     .safe { padding-bottom: env(safe-area-inset-bottom); }
-    .divider{ 
-      @apply h-px w-full bg-white/10 my-3;
+    .divider{
+      height: 1px;
+      width: 100%;
+      background: rgba(255,255,255,0.1);
+      margin: 0.75rem 0;
     }
     .card-hover {
       transition: all 0.3s ease;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -28,7 +28,7 @@ app.use(helmet({
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'", "https://cdn.tailwindcss.com"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://cdnjs.cloudflare.com"],
-      fontSrc: ["'self'", "https://fonts.gstatic.com", "data:"],
+      fontSrc: ["'self'", "https://fonts.gstatic.com", "https://cdnjs.cloudflare.com", "data:"],
       imgSrc: ["'self'", "data:", "https://i.pravatar.cc"],
       connectSrc: ["'self'"],
       objectSrc: ["'none'"],


### PR DESCRIPTION
## Summary
- allow Font Awesome assets from cdnjs in the helmet CSP so the admin panel icons load under the current policy
- replace unsupported Tailwind `@apply` directives with equivalent vanilla CSS rules to prevent console warnings

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cbb2943ae48326b27c4ce688a3d8fd