### PR TITLE
Display imported trivia questions in admin panel

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -296,6 +296,16 @@
       background: linear-gradient(135deg, rgba(248,113,113,0.18), rgba(239,68,68,0.15));
       color: #f87171;
     }
+    .meta-chip.source-manual {
+      border-color: rgba(96, 165, 250, 0.35);
+      background: linear-gradient(135deg, rgba(96,165,250,0.16), rgba(129,140,248,0.12));
+      color: #bfdbfe;
+    }
+    .meta-chip.source-opentdb {
+      border-color: rgba(236, 72, 153, 0.4);
+      background: linear-gradient(135deg, rgba(236,72,153,0.16), rgba(129,140,248,0.14));
+      color: #fbcfe8;
+    }
     .meta-chip.status-active {
       border-color: rgba(34, 197, 94, 0.4);
       background: linear-gradient(135deg, rgba(16,185,129,0.18), rgba(34,197,94,0.12));
@@ -440,6 +450,23 @@
       font-size: 2rem;
       color: rgba(226, 232, 240, 0.45);
     }
+    .loading-state {
+      padding: 2.5rem 1rem;
+      text-align: center;
+      color: rgba(226, 232, 240, 0.78);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.85rem;
+    }
+    .loading-spinner {
+      width: 44px;
+      height: 44px;
+      border-radius: 999px;
+      border: 3px solid rgba(148, 163, 184, 0.35);
+      border-top-color: rgba(250, 204, 21, 0.85);
+      animation: spin 0.9s linear infinite;
+    }
     .form-input {
       width: 100%;
       padding: 0.75rem 1rem;
@@ -522,14 +549,18 @@
       to { opacity: 1; }
     }
     @keyframes slideUp {
-      from { 
+      from {
         opacity: 0;
         transform: translateY(20px);
       }
-      to { 
+      to {
         opacity: 1;
         transform: translateY(0);
       }
+    }
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
     }
     /* Responsive adjustments */
     @media (max-width: 768px) {
@@ -1051,7 +1082,7 @@
 
         <!-- Filters -->
         <div class="glass rounded-2xl p-4">
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
             <div>
               <label class="block text-sm mb-1">دسته‌بندی</label>
               <select id="filter-category" class="form-select">
@@ -1069,7 +1100,19 @@
             </div>
             <div>
               <label class="block text-sm mb-1">جستجو</label>
-              <input id="filter-search" type="search" placeholder="جستجوی سوال..." class="form-input">
+              <div class="relative">
+                <input id="filter-search" type="search" placeholder="جستجوی سوال..." class="form-input pr-12">
+                <span class="absolute inset-y-0 left-4 flex items-center text-white/60 pointer-events-none">
+                  <i class="fa-solid fa-magnifying-glass"></i>
+                </span>
+              </div>
+            </div>
+            <div>
+              <label class="block text-sm mb-1">مرتب‌سازی</label>
+              <select id="filter-sort" class="form-select">
+                <option value="newest">جدیدترین سوالات</option>
+                <option value="oldest">قدیمی‌ترین سوالات</option>
+              </select>
             </div>
           </div>
         </div>
@@ -1087,58 +1130,12 @@
                 </tr>
               </thead>
               <tbody id="questions-tbody">
-                <tr>
-                  <td data-label="شناسه" class="font-mono text-sm text-white/70">#۱۰۲۴</td>
-                  <td data-label="سوال و جزئیات">
-                    <div class="question-text line-clamp-2" title="پایتخت استرالیا کدام است؟">پایتخت استرالیا کدام است؟</div>
-                    <div class="question-meta">
-                      <span class="meta-chip category"><i class="fa-solid fa-layer-group"></i>جغرافیا</span>
-                      <span class="meta-chip difficulty-easy"><i class="fa-solid fa-feather"></i>آسون</span>
-                      <span class="meta-chip status-active"><span class="status-dot active"></span>فعال</span>
+                <tr class="loading-row">
+                  <td colspan="4">
+                    <div class="loading-state">
+                      <span class="loading-spinner"></span>
+                      <p>برای مشاهده سوالات لطفاً وارد شوید یا لحظاتی صبر کنید...</p>
                     </div>
-                  </td>
-                  <td data-label="پاسخ صحیح">
-                    <div class="answer-pill" title="کانبرا"><i class="fa-solid fa-lightbulb"></i><span>کانبرا</span></div>
-                  </td>
-                  <td data-label="عملیات" class="actions">
-                    <button class="action-btn view" title="مشاهده و ویرایش"><i class="fa-solid fa-eye"></i></button>
-                    <button class="action-btn delete" title="حذف سوال"><i class="fa-solid fa-trash"></i></button>
-                  </td>
-                </tr>
-                <tr>
-                  <td data-label="شناسه" class="font-mono text-sm text-white/70">#۱۰۲۳</td>
-                  <td data-label="سوال و جزئیات">
-                    <div class="question-text line-clamp-2" title="کدام سیاره در منظومه شمسی بزرگترین است؟">کدام سیاره در منظومه شمسی بزرگترین است؟</div>
-                    <div class="question-meta">
-                      <span class="meta-chip category"><i class="fa-solid fa-layer-group"></i>علم</span>
-                      <span class="meta-chip difficulty-easy"><i class="fa-solid fa-feather"></i>آسون</span>
-                      <span class="meta-chip status-active"><span class="status-dot active"></span>فعال</span>
-                    </div>
-                  </td>
-                  <td data-label="پاسخ صحیح">
-                    <div class="answer-pill" title="سیاره مشتری"><i class="fa-solid fa-lightbulb"></i><span>سیاره مشتری</span></div>
-                  </td>
-                  <td data-label="عملیات" class="actions">
-                    <button class="action-btn view" title="مشاهده و ویرایش"><i class="fa-solid fa-eye"></i></button>
-                    <button class="action-btn delete" title="حذف سوال"><i class="fa-solid fa-trash"></i></button>
-                  </td>
-                </tr>
-                <tr>
-                  <td data-label="شناسه" class="font-mono text-sm text-white/70">#۱۰۲۲</td>
-                  <td data-label="سوال و جزئیات">
-                    <div class="question-text line-clamp-2" title="طولانی‌ترین رود جهان کدام است؟">طولانی‌ترین رود جهان کدام است؟</div>
-                    <div class="question-meta">
-                      <span class="meta-chip category"><i class="fa-solid fa-layer-group"></i>جغرافیا</span>
-                      <span class="meta-chip difficulty-medium"><i class="fa-solid fa-wave-square"></i>متوسط</span>
-                      <span class="meta-chip status-pending"><span class="status-dot pending"></span>در حال بررسی</span>
-                    </div>
-                  </td>
-                  <td data-label="پاسخ صحیح">
-                    <div class="answer-pill" title="رود نیل"><i class="fa-solid fa-lightbulb"></i><span>رود نیل</span></div>
-                  </td>
-                  <td data-label="عملیات" class="actions">
-                    <button class="action-btn view" title="مشاهده و ویرایش"><i class="fa-solid fa-eye"></i></button>
-                    <button class="action-btn delete" title="حذف سوال"><i class="fa-solid fa-trash"></i></button>
                   </td>
                 </tr>
               </tbody>

--- a/server/src/models/Question.js
+++ b/server/src/models/Question.js
@@ -22,7 +22,8 @@ const questionSchema = new mongoose.Schema(
     difficulty: { type: String, enum: ['easy', 'medium', 'hard'], default: 'easy' },
     category: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
     categoryName: { type: String, trim: true },
-    active: { type: Boolean, default: true }
+    active: { type: Boolean, default: true },
+    source: { type: String, enum: ['manual', 'opentdb'], default: 'manual' }
   },
   { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } }
 );

--- a/server/src/services/triviaImporter.js
+++ b/server/src/services/triviaImporter.js
@@ -68,7 +68,8 @@ async function fetchAndStoreTriviaBatch() {
       correctIndex,
       difficulty: item.difficulty || 'easy',
       category: categoryDoc._id,
-      categoryName
+      categoryName,
+      source: 'opentdb'
     });
   }
 


### PR DESCRIPTION
## Summary
- add UI polish for the question manager including a sorting filter, loading state, and OpenTDB source badges
- decode imported question text/options and show OpenTDB items by tagging stored questions with a `source`
- allow sorting on the questions API and persist the source on creation/import so admin lists stay in sync

## Testing
- node --check Admin-Panel.js
- node --check server/src/controllers/questions.controller.js
- node --check server/src/models/Question.js
- node --check server/src/services/triviaImporter.js

------
https://chatgpt.com/codex/tasks/task_e_68cbc52edb748326895470360c825c5a