### PR TITLE
Add real question statistics to admin dashboard

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -908,15 +908,35 @@
             <div class="text-sm opacity-80">کاربران فعال</div>
           </div>
           
-          <div class="glass rounded-2xl p-5 stat-card">
+          <div class="glass rounded-2xl p-5 stat-card cursor-pointer transition-transform duration-300" data-dashboard-card="questions" role="button" tabindex="0">
             <div class="flex items-center justify-between mb-3">
               <div class="w-12 h-12 rounded-full bg-green-500/20 flex items-center justify-center">
                 <i class="fa-solid fa-question-circle text-green-400 text-xl"></i>
               </div>
-              <span class="text-xs text-green-400 font-bold">+۸٪</span>
+              <span id="dashboard-question-trend" class="text-xs font-bold text-emerald-400 bg-emerald-500/10 rounded-xl px-2 py-1">+۰٪</span>
             </div>
-            <div class="text-2xl font-bold mb-1">۱,۲۳۴</div>
+            <div id="dashboard-question-total" class="text-2xl font-bold mb-1">۰</div>
             <div class="text-sm opacity-80">سوالات</div>
+            <div class="mt-4 grid grid-cols-2 gap-2 text-xs text-white/80">
+              <div class="glass-dark rounded-xl px-3 py-2 flex flex-col gap-1">
+                <div class="flex items-center justify-between">
+                  <span class="font-semibold">امروز</span>
+                  <span class="w-2 h-2 rounded-full bg-emerald-400 shadow-sm"></span>
+                </div>
+                <div id="dashboard-question-today" class="text-sm font-bold text-white">۰</div>
+              </div>
+              <div class="glass-dark rounded-xl px-3 py-2 flex flex-col gap-1">
+                <div class="flex items-center justify-between">
+                  <span class="font-semibold">دیروز</span>
+                  <span class="w-2 h-2 rounded-full bg-sky-400/80 shadow-sm"></span>
+                </div>
+                <div id="dashboard-question-yesterday" class="text-sm font-bold text-white/90">۰</div>
+              </div>
+            </div>
+            <div class="text-[0.7rem] text-white/60 mt-3 flex items-center gap-1 justify-end">
+              <i class="fa-solid fa-circle-info text-white/40"></i>
+              <span>برای جزئیات بیشتر کلیک کنید</span>
+            </div>
           </div>
           
           <div class="glass rounded-2xl p-5 stat-card">
@@ -2014,6 +2034,57 @@
   </div>
 
   <!-- Modals -->
+  <div id="question-stats-modal" class="modal">
+    <div class="glass rounded-3xl max-w-lg w-full mx-4 modal-content overflow-hidden shadow-2xl">
+      <div class="p-6 pb-4 border-b border-white/10 flex items-center justify-between">
+        <div>
+          <h3 class="text-xl font-extrabold">آمار لحظه‌ای سوالات</h3>
+          <p id="question-stats-summary" class="text-sm text-white/70 mt-1">برای مشاهده جزئیات ابتدا وارد شوید.</p>
+        </div>
+        <button type="button" class="close-modal w-9 h-9 rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors">
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+      <div class="p-6 space-y-5">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div class="glass-dark rounded-2xl px-4 py-3 flex flex-col gap-2">
+            <span class="text-xs text-white/60">کل سوالات</span>
+            <span id="question-stats-total" class="text-2xl font-extrabold">۰</span>
+          </div>
+          <div class="glass-dark rounded-2xl px-4 py-3 flex flex-col gap-2">
+            <span class="text-xs text-white/60">امروز اضافه شد</span>
+            <span id="question-stats-today" class="text-xl font-bold text-emerald-300">۰</span>
+          </div>
+          <div class="glass-dark rounded-2xl px-4 py-3 flex flex-col gap-2">
+            <span class="text-xs text-white/60">دیروز اضافه شد</span>
+            <span id="question-stats-yesterday" class="text-xl font-bold text-sky-300">۰</span>
+          </div>
+        </div>
+        <div class="glass-dark rounded-2xl px-4 py-4 flex flex-col gap-3 border border-white/5">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <span class="w-2.5 h-2.5 rounded-full bg-emerald-400 shadow"></span>
+              <span class="text-sm text-white/80">تغییر نسبت به دیروز</span>
+            </div>
+            <span id="question-stats-percent" class="text-sm font-bold text-emerald-300">+۰٪</span>
+          </div>
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-white/70">تفاضل تعداد سوالات جدید</span>
+            <span id="question-stats-delta" class="text-base font-bold text-white">۰</span>
+          </div>
+          <p id="question-stats-description" class="text-xs text-white/60 leading-6">
+            پس از ورود به پنل، آخرین تغییرات این بخش به صورت لحظه‌ای محاسبه و نمایش داده می‌شود.
+          </p>
+        </div>
+      </div>
+      <div class="p-6 pt-0 border-t border-white/10 flex justify-end gap-3 safe">
+        <button type="button" class="btn btn-secondary close-modal w-auto px-5">
+          <i class="fa-solid fa-arrow-right ml-2"></i>
+          <span>بستن</span>
+        </button>
+      </div>
+    </div>
+  </div>
   <!-- Add Question Modal -->
   <!-- Question Detail Modal -->
   <div id="question-detail-modal" class="modal">

--- a/server/src/controllers/questions.controller.js
+++ b/server/src/controllers/questions.controller.js
@@ -63,3 +63,24 @@ exports.remove = async (req, res, next) => {
     res.json({ ok:true });
   } catch (e) { next(e); }
 };
+
+exports.statsSummary = async (req, res, next) => {
+  try {
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startOfTomorrow = new Date(startOfToday);
+    startOfTomorrow.setDate(startOfTomorrow.getDate() + 1);
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+
+    const [total, today, yesterday] = await Promise.all([
+      Question.countDocuments(),
+      Question.countDocuments({ createdAt: { $gte: startOfToday, $lt: startOfTomorrow } }),
+      Question.countDocuments({ createdAt: { $gte: startOfYesterday, $lt: startOfToday } })
+    ]);
+
+    res.json({ ok: true, data: { total, today, yesterday } });
+  } catch (e) {
+    next(e);
+  }
+};

--- a/server/src/routes/questions.routes.js
+++ b/server/src/routes/questions.routes.js
@@ -4,6 +4,7 @@ const ctrl = require('../controllers/questions.controller');
 
 router.use(protect, adminOnly);
 router.get('/', ctrl.list);
+router.get('/stats/summary', ctrl.statsSummary);
 router.post('/', ctrl.create);
 router.put('/:id', ctrl.update);
 router.delete('/:id', ctrl.remove);


### PR DESCRIPTION
## Summary
- add an authenticated question statistics summary endpoint to expose total, today, and yesterday counts
- enhance the dashboard question card to show real counts, daily breakdown, and trigger a detailed modal
- build a responsive modal with localized copy to present daily trends when the card is clicked

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbc98842988326a8673f444acf073c