### PR TITLE
Improve add question modal responsiveness

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -188,6 +188,133 @@
     .modal.active .modal-content {
       transform: translateY(0);
     }
+    #add-question-modal .modal-content {
+      width: min(100%, 640px);
+      max-height: calc(100vh - 2.5rem);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      padding: 0;
+    }
+    #add-question-modal .modal-header {
+      padding: 1.75rem 1.75rem 1.25rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    #add-question-modal .modal-header > div {
+      flex: 1;
+      min-width: 0;
+    }
+    #add-question-modal .modal-header h3 {
+      font-size: 1.4rem;
+      line-height: 1.7;
+    }
+    #add-question-modal .modal-header .close-modal {
+      width: 2.5rem;
+      height: 2.5rem;
+      flex-shrink: 0;
+    }
+    #add-question-modal .modal-body {
+      padding: 1.5rem 1.75rem 1.75rem;
+      overflow-y: auto;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      scrollbar-gutter: stable both-edges;
+      min-height: 0;
+    }
+    #add-question-modal .field-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    #add-question-modal .field-group > label {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: rgba(226, 232, 240, 0.9);
+    }
+    #add-question-modal .field-label {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: rgba(226, 232, 240, 0.9);
+    }
+    #add-question-modal .helper-text {
+      font-size: 0.75rem;
+      color: rgba(148, 163, 184, 0.9);
+    }
+    #add-question-modal .field-group > .helper-text {
+      line-height: 1.6;
+      display: block;
+    }
+    #add-question-modal .select-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+    #add-question-modal .options-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    #add-question-modal .option-row {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.85rem 1rem;
+      border-radius: 0.9rem;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      transition: all 0.3s ease;
+    }
+    #add-question-modal .option-row:hover {
+      border-color: rgba(148, 163, 184, 0.3);
+      background: rgba(15, 23, 42, 0.65);
+    }
+    #add-question-modal .option-row:focus-within {
+      border-color: var(--accent1);
+      box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
+      background: rgba(15, 23, 42, 0.75);
+    }
+    #add-question-modal .option-row:has(input[type="radio"]:checked) {
+      border-color: var(--accent2);
+      box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.18);
+      background: rgba(15, 23, 42, 0.82);
+    }
+    #add-question-modal .option-row input[type="radio"] {
+      width: 1.25rem;
+      height: 1.25rem;
+      accent-color: var(--accent2);
+    }
+    #add-question-modal .option-row .form-input {
+      padding: 0.2rem 0;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      min-width: 0;
+    }
+    #add-question-modal .option-row .form-input:focus {
+      outline: none;
+      border: none;
+      box-shadow: none;
+      background: transparent;
+    }
+    #add-question-modal .option-row .form-input::placeholder {
+      color: rgba(148, 163, 184, 0.75);
+    }
+    #add-question-modal .modal-actions {
+      padding: 1.5rem 1.75rem 1.75rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      gap: 0.75rem;
+    }
+    #add-question-modal .modal-actions .btn {
+      flex: 1;
+    }
     #question-detail-modal .modal-body {
       -webkit-overflow-scrolling: touch;
       overscroll-behavior: contain;
@@ -585,6 +712,14 @@
         width: 95%;
         margin: 0 auto;
       }
+      #add-question-modal .modal-content {
+        width: 100%;
+        max-height: calc(100vh - 1.5rem);
+      }
+      #add-question-modal .select-grid {
+        grid-template-columns: 1fr;
+        gap: 0.85rem;
+      }
     }
     @media (max-width: 768px) {
       .table-questions thead {
@@ -629,6 +764,75 @@
       .question-meta .meta-chip {
         width: 100%;
         justify-content: flex-start;
+      }
+    }
+    @media (max-width: 640px) {
+      #add-question-modal {
+        padding: 0;
+        align-items: stretch;
+        justify-content: flex-start;
+      }
+      #add-question-modal .modal-content {
+        border-radius: 0;
+        margin: 0;
+        width: 100%;
+        max-width: none;
+        height: 100%;
+        max-height: none;
+        box-shadow: none;
+      }
+      #add-question-modal .modal-header {
+        padding: calc(1.25rem + env(safe-area-inset-top)) 1.25rem 1rem;
+        position: sticky;
+        top: 0;
+        right: 0;
+        background: rgba(15, 23, 42, 0.96);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        z-index: 1;
+      }
+      #add-question-modal .modal-header h3 {
+        font-size: 1.25rem;
+      }
+      #add-question-modal .modal-body {
+        padding: 1.1rem 1.25rem 1.5rem;
+        gap: 1rem;
+      }
+      #add-question-modal .modal-actions {
+        padding: 1rem 1.25rem calc(1rem + env(safe-area-inset-bottom));
+        flex-direction: column;
+        background: rgba(15, 23, 42, 0.96);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+      }
+      #add-question-modal .modal-actions .btn {
+        width: 100%;
+      }
+      #add-question-modal .option-row {
+        gap: 0.7rem;
+      }
+      #add-question-modal .option-row input[type="radio"] {
+        justify-self: flex-start;
+      }
+    }
+    @media (max-width: 480px) {
+      #add-question-modal .modal-header {
+        padding: calc(1rem + env(safe-area-inset-top)) 1rem 0.85rem;
+      }
+      #add-question-modal .modal-header h3 {
+        font-size: 1.15rem;
+      }
+      #add-question-modal .modal-body {
+        padding: 1rem 1rem 1.25rem;
+      }
+      #add-question-modal .helper-text {
+        font-size: 0.7rem;
+      }
+      #add-question-modal .option-row {
+        padding: 0.75rem 0.85rem;
+      }
+      #add-question-modal .modal-actions {
+        gap: 0.65rem;
       }
     }
     @media (max-width: 640px) {
@@ -2147,63 +2351,72 @@
   </div>
 
   <div id="add-question-modal" class="modal">
-    <div class="glass rounded-3xl p-6 max-w-2xl w-full mx-4 modal-content">
-      <div class="flex items-center justify-between mb-4">
-        <h3 class="text-xl font-extrabold">افزودن سوال جدید</h3>
-        <button class="close-modal w-8 h-8 rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors">
+    <div class="glass rounded-3xl max-w-2xl w-full mx-4 modal-content">
+      <div class="modal-header">
+        <div>
+          <h3 class="font-extrabold text-2xl md:text-3xl">افزودن سوال جدید</h3>
+          <p class="helper-text mt-1">لطفاً سوال و گزینه‌های آن را با دقت تکمیل کنید تا تجربه کاربری بهتری برای شرکت‌کنندگان فراهم شود.</p>
+        </div>
+        <button type="button" class="close-modal rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors">
           <i class="fa-solid fa-times"></i>
         </button>
       </div>
-      <div class="space-y-4">
-        <div>
-          <label class="block text-sm mb-1">متن سوال</label>
-          <textarea class="form-input" rows="3" placeholder="متن سوال را وارد کنید..."></textarea>
+      <div class="modal-body">
+        <div class="field-group">
+          <label>متن سوال</label>
+          <textarea class="form-input min-h-[130px] text-sm leading-relaxed" rows="4" placeholder="متن سوال را وارد کنید..."></textarea>
+          <span class="helper-text">برای وضوح بیشتر، سوال را کوتاه و دقیق بنویسید.</span>
         </div>
-        <div>
-          <label class="block text-sm mb-1">دسته‌بندی</label>
-          <select class="form-select">
-            <option>عمومی</option>
-            <option>جغرافیا</option>
-            <option>ورزش</option>
-            <option>علم</option>
-            <option>تاریخ</option>
-            <option>هنر</option>
-            <option>سرگرمی</option>
-          </select>
+        <div class="select-grid">
+          <div class="field-group">
+            <label>دسته‌بندی</label>
+            <select class="form-select">
+              <option>عمومی</option>
+              <option>جغرافیا</option>
+              <option>ورزش</option>
+              <option>علم</option>
+              <option>تاریخ</option>
+              <option>هنر</option>
+              <option>سرگرمی</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label>سطح دشواری</label>
+            <select class="form-select">
+              <option>آسون</option>
+              <option>متوسط</option>
+              <option>سخت</option>
+            </select>
+          </div>
         </div>
-        <div>
-          <label class="block text-sm mb-1">سطح دشواری</label>
-          <select class="form-select">
-            <option>آسون</option>
-            <option>متوسط</option>
-            <option>سخت</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm mb-1">گزینه‌ها</label>
-          <div class="space-y-2">
-            <div class="flex items-center gap-2">
-              <input type="radio" name="correct-answer" class="w-5 h-5">
-              <input type="text" class="form-input flex-1" placeholder="گزینه ۱">
+        <div class="field-group">
+          <div class="flex items-center justify-between gap-2 flex-wrap">
+            <span class="field-label">گزینه‌ها</span>
+            <span class="helper-text">گزینه صحیح را انتخاب کنید.</span>
+          </div>
+          <div class="options-wrapper">
+            <div class="option-row">
+              <input type="radio" name="correct-answer">
+              <input type="text" class="form-input" placeholder="گزینه ۱">
             </div>
-            <div class="flex items-center gap-2">
-              <input type="radio" name="correct-answer" class="w-5 h-5">
-              <input type="text" class="form-input flex-1" placeholder="گزینه ۲">
+            <div class="option-row">
+              <input type="radio" name="correct-answer">
+              <input type="text" class="form-input" placeholder="گزینه ۲">
             </div>
-            <div class="flex items-center gap-2">
-              <input type="radio" name="correct-answer" class="w-5 h-5">
-              <input type="text" class="form-input flex-1" placeholder="گزینه ۳">
+            <div class="option-row">
+              <input type="radio" name="correct-answer">
+              <input type="text" class="form-input" placeholder="گزینه ۳">
             </div>
-            <div class="flex items-center gap-2">
-              <input type="radio" name="correct-answer" class="w-5 h-5">
-              <input type="text" class="form-input flex-1" placeholder="گزینه ۴">
+            <div class="option-row">
+              <input type="radio" name="correct-answer">
+              <input type="text" class="form-input" placeholder="گزینه ۴">
             </div>
           </div>
         </div>
-        <div class="flex gap-3">
-          <button class="btn btn-secondary">انصراف</button>
-          <button id="save-question-btn" class="btn btn-primary">ذخیره سوال</button>
-        </div>
+      </div>
+      <div class="modal-actions safe">
+        <button type="button" id="save-question-btn" class="btn btn-primary">ذخیره سوال</button>
+        <button type="button" class="btn btn-secondary close-modal">انصراف</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- refactor the add question modal structure with dedicated header, body, and actions sections for better usability
- add tailored styling and responsive breakpoints to make the add question modal mobile friendly and highlight the selected option

## Testing
- not run (static HTML only)


------
https://chatgpt.com/codex/tasks/task_e_68cbd33c279c8326a13bdc6960ffa32e