### PR TITLE
Allow inline scripts for bot page

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,7 +26,7 @@ app.use(helmet({
     useDefaults: true,
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "https://cdn.tailwindcss.com"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.tailwindcss.com"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://cdnjs.cloudflare.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com", "https://cdnjs.cloudflare.com", "data:"],
       imgSrc: ["'self'", "data:", "https://i.pravatar.cc"],


### PR DESCRIPTION
## Summary
- allow inline scripts in the Helmet CSP configuration so the bot page can execute its embedded script and dismiss the loading screen

## Testing
- not run (server requires external services)


------
https://chatgpt.com/codex/tasks/task_e_68cbe22d1b088326b964413f4ffbe1ce