### PR TITLE
Add The Trivia API importer support

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -2,6 +2,9 @@ PORT=4000
 NODE_ENV=development
 MONGO_URI=mongodb://localhost:27017/iquiz
 
+# Trivia providers
+THETRIVIA_URL=https://the-trivia-api.com/v2/questions?limit=20
+
 # Admin seed
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=ChangeThis!123

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,6 +12,9 @@ JWT_EXPIRES_IN=7d
 # CORS (کامای جدا)
 ALLOWED_ORIGINS=http://localhost:5500,http://127.0.0.1:5500,https://your-admin-domain.com
 
+# Trivia providers
+THETRIVIA_URL=https://the-trivia-api.com/v2/questions?limit=20
+
 # Admin seed
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=Admin123!

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -5,6 +5,7 @@ const DEFAULT_NODE_ENV = 'development';
 const DEFAULT_MONGO_URI = 'mongodb://localhost:27017/iquiz';
 const DEFAULT_TRIVIA_URL = 'https://opentdb.com/api.php?amount=20&type=multiple';
 const DEFAULT_TRIVIA_INTERVAL = 5000;
+const DEFAULT_THE_TRIVIA_URL = 'https://the-trivia-api.com/v2/questions?limit=20';
 const DEFAULT_MONGO_MAX_POOL = 10;
 
 const truthyValues = new Set(['true', '1', 'yes', 'y', 'on']);
@@ -51,6 +52,7 @@ const pollerIntervalMs = parseNumber(process.env.TRIVIA_POLLER_INTERVAL_MS, DEFA
 const pollerMaxRunsCandidate = parseNumber(process.env.TRIVIA_POLLER_MAX_RUNS, 0, { min: 0 });
 const pollerMaxRuns = pollerMaxRunsCandidate > 0 ? Math.floor(pollerMaxRunsCandidate) : null;
 const triviaUrl = process.env.TRIVIA_URL || DEFAULT_TRIVIA_URL;
+const theTriviaUrl = process.env.THETRIVIA_URL || DEFAULT_THE_TRIVIA_URL;
 const port = parseNumber(process.env.PORT, DEFAULT_PORT, { min: 1 });
 const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
 
@@ -66,7 +68,8 @@ const env = {
     enablePoller: enableTriviaPoller,
     pollerIntervalMs,
     pollerMaxRuns,
-    url: triviaUrl
+    url: triviaUrl,
+    theTriviaUrl
   },
   cors: {
     allowedOrigins

--- a/server/src/controllers/questions.controller.js
+++ b/server/src/controllers/questions.controller.js
@@ -31,7 +31,7 @@ exports.list = async (req, res, next) => {
     if (q) where.text = { $regex: q, $options: 'i' };
     if (category) where.category = category;
     if (difficulty) where.difficulty = difficulty;
-    if (source && ['manual', 'opentdb'].includes(source)) where.source = source;
+    if (source && ['manual', 'opentdb', 'the-trivia-api'].includes(source)) where.source = source;
 
     const normalizedSort = typeof sort === 'string' ? sort.toLowerCase() : 'newest';
     const sortOption = normalizedSort === 'oldest'

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -92,6 +92,7 @@ app.use('/api/questions', require('./routes/questions.routes'));
 app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/achievements', require('./routes/achievements.routes'));
 app.use('/api/trivia', triviaRoutes);
+app.use('/api', require('./routes/trivia-triviaapi'));
 
 // error handler
 app.use(errorHandler);

--- a/server/src/models/Question.js
+++ b/server/src/models/Question.js
@@ -43,7 +43,7 @@ const questionSchema = new mongoose.Schema(
     category: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
     categoryName: { type: String, trim: true },
     active: { type: Boolean, default: true },
-    source: { type: String, enum: ['manual', 'opentdb'], default: 'manual' },
+    source: { type: String, enum: ['manual', 'opentdb', 'the-trivia-api'], default: 'manual' },
     lang: { type: String, trim: true, default: 'en' },
     type: { type: String, trim: true, default: 'multiple' },
     checksum: { type: String, required: true, trim: true }

--- a/server/src/providers/thetrivia.js
+++ b/server/src/providers/thetrivia.js
@@ -1,0 +1,105 @@
+const env = require('../config/env');
+const logger = require('../config/logger');
+const { fetchWithRetry } = require('../lib/http');
+
+const DEFAULT_CATEGORY = 'General Knowledge';
+const ALLOWED_DIFFICULTIES = new Set(['easy', 'medium', 'hard']);
+
+function sanitizeText(value) {
+  if (value === undefined || value === null) return '';
+  return String(value).trim();
+}
+
+function normalizeDifficulty(value) {
+  const normalized = sanitizeText(value).toLowerCase();
+  return ALLOWED_DIFFICULTIES.has(normalized) ? normalized : 'medium';
+}
+
+function normalizeQuestion(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const questionText = sanitizeText(raw.question?.text ?? raw.question);
+  const correctAnswer = sanitizeText(raw.correctAnswer);
+  const incorrectAnswersRaw = Array.isArray(raw.incorrectAnswers)
+    ? raw.incorrectAnswers.map(sanitizeText)
+    : [];
+
+  if (!questionText || !correctAnswer) {
+    return null;
+  }
+
+  const incorrectAnswers = [];
+  const seenIncorrect = new Set();
+  const correctKey = correctAnswer.toLowerCase();
+  for (const answer of incorrectAnswersRaw) {
+    if (!answer) continue;
+    const key = answer.toLowerCase();
+    if (key === correctKey) continue;
+    if (seenIncorrect.has(key)) continue;
+    seenIncorrect.add(key);
+    incorrectAnswers.push(answer);
+  }
+
+  if (incorrectAnswers.length === 0) {
+    return null;
+  }
+
+  const categoryName = sanitizeText(raw.category) || DEFAULT_CATEGORY;
+
+  return {
+    source: 'the-trivia-api',
+    question: questionText,
+    correctAnswer,
+    incorrectAnswers,
+    categoryName,
+    difficulty: normalizeDifficulty(raw.difficulty),
+    type: 'multiple',
+    lang: 'en'
+  };
+}
+
+async function getFromTheTriviaAPI(url = env.trivia.theTriviaUrl) {
+  const targetUrl = sanitizeText(url) || env.trivia.theTriviaUrl;
+
+  if (!targetUrl) {
+    throw new Error('The Trivia API URL is not configured');
+  }
+
+  let response;
+  try {
+    response = await fetchWithRetry(targetUrl, {
+      timeout: 15000,
+      retries: 2,
+      retryDelay: ({ attempt }) => attempt * 500,
+      headers: { Accept: 'application/json' }
+    });
+  } catch (error) {
+    logger.error(`[TheTriviaAPI] Failed to reach provider: ${error.message}`);
+    throw new Error('Failed to reach The Trivia API');
+  }
+
+  if (!response.ok) {
+    const error = new Error(`The Trivia API request failed with status ${response.status}`);
+    logger.error(error.message);
+    throw error;
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    logger.error('[TheTriviaAPI] Failed to parse JSON response', error);
+    throw new Error('Failed to parse The Trivia API response as JSON');
+  }
+
+  if (!Array.isArray(payload)) {
+    throw new Error('The Trivia API returned an unexpected payload');
+  }
+
+  return payload.map(normalizeQuestion).filter(Boolean);
+}
+
+module.exports = {
+  getFromTheTriviaAPI,
+};
+

--- a/server/src/routes/trivia-triviaapi.js
+++ b/server/src/routes/trivia-triviaapi.js
@@ -1,0 +1,200 @@
+const router = require('express').Router();
+
+const env = require('../config/env');
+const { protect, adminOnly } = require('../middleware/auth');
+const Category = require('../models/Category');
+const Question = require('../models/Question');
+const { getFromTheTriviaAPI } = require('../providers/thetrivia');
+
+const DEFAULT_CATEGORY = 'General Knowledge';
+const MAX_LIMIT = 50;
+
+function sanitizeText(value) {
+  if (value === undefined || value === null) return '';
+  return String(value).trim();
+}
+
+function shuffle(array) {
+  const cloned = [...array];
+  for (let i = cloned.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cloned[i], cloned[j]] = [cloned[j], cloned[i]];
+  }
+  return cloned;
+}
+
+async function ensureCategories(names) {
+  const uniqueNames = [...new Set((names || []).map(name => sanitizeText(name)).filter(Boolean))];
+  const categoryMap = new Map();
+
+  if (uniqueNames.length === 0) {
+    return categoryMap;
+  }
+
+  const existing = await Category.find({ name: { $in: uniqueNames } });
+  existing.forEach(category => {
+    categoryMap.set(category.name, category);
+  });
+
+  const missing = uniqueNames.filter(name => !categoryMap.has(name));
+
+  for (const name of missing) {
+    const category = await Category.findOneAndUpdate(
+      { name },
+      { name },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      }
+    );
+    categoryMap.set(category.name, category);
+  }
+
+  return categoryMap;
+}
+
+function normalizeAnswers(correctAnswer, incorrectAnswers) {
+  const correct = sanitizeText(correctAnswer);
+  if (!correct) return null;
+
+  const answers = [];
+  const seen = new Set();
+  const correctKey = correct.toLowerCase();
+  seen.add(correctKey);
+  answers.push(correct);
+
+  for (const answer of Array.isArray(incorrectAnswers) ? incorrectAnswers : []) {
+    const normalized = sanitizeText(answer);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    answers.push(normalized);
+    if (answers.length === 4) break;
+  }
+
+  if (answers.length !== 4) {
+    return null;
+  }
+
+  return { answers, correct };
+}
+
+function buildTriviaApiUrl(baseUrl, params = {}) {
+  const normalizedBase = sanitizeText(baseUrl);
+  const url = new URL(normalizedBase || 'https://the-trivia-api.com/v2/questions?limit=20');
+
+  const { limit: rawLimit, ...rest } = params || {};
+
+  if (rawLimit !== undefined) {
+    const parsedLimit = Number.parseInt(rawLimit, 10);
+    if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) {
+      const error = new Error('limit must be a positive integer');
+      error.statusCode = 400;
+      throw error;
+    }
+    const bounded = Math.min(Math.max(parsedLimit, 1), MAX_LIMIT);
+    url.searchParams.set('limit', String(bounded));
+  }
+
+  for (const [key, value] of Object.entries(rest)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      const normalizedItems = value.map(item => sanitizeText(item)).filter(Boolean);
+      if (normalizedItems.length === 0) continue;
+      url.searchParams.set(key, normalizedItems.join(','));
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      continue;
+    }
+
+    const normalizedValue = sanitizeText(value);
+    if (!normalizedValue) continue;
+    url.searchParams.set(key, normalizedValue);
+  }
+
+  return url.toString();
+}
+
+router.post('/trivia/import/triviaapi', protect, adminOnly, async (req, res, next) => {
+  try {
+    const requestBody = req.body && typeof req.body === 'object' ? req.body : {};
+    const requestUrl = buildTriviaApiUrl(env.trivia.theTriviaUrl, requestBody);
+
+    const questions = await getFromTheTriviaAPI(requestUrl);
+
+    if (questions.length === 0) {
+      return res.json({ ok: true, count: 0 });
+    }
+
+    const categoryMap = await ensureCategories(
+      questions.map(question => question.categoryName || DEFAULT_CATEGORY)
+    );
+
+    const operations = [];
+    for (const question of questions) {
+      const categoryName = question.categoryName || DEFAULT_CATEGORY;
+      const categoryDoc = categoryMap.get(categoryName);
+      if (!categoryDoc) {
+        continue;
+      }
+
+      const normalized = normalizeAnswers(question.correctAnswer, question.incorrectAnswers);
+      if (!normalized) {
+        continue;
+      }
+
+      const { answers, correct } = normalized;
+      const choices = shuffle(answers);
+      const correctIndex = choices.findIndex(choice => choice === correct);
+      if (correctIndex < 0) {
+        continue;
+      }
+
+      const checksum = Question.generateChecksum(question.question, answers);
+
+      const document = {
+        text: question.question,
+        choices,
+        correctIndex,
+        difficulty: question.difficulty,
+        category: categoryDoc._id,
+        categoryName,
+        source: question.source,
+        type: question.type,
+        lang: question.lang,
+        checksum,
+        active: true
+      };
+
+      operations.push({
+        updateOne: {
+          filter: { checksum },
+          update: { $setOnInsert: document },
+          upsert: true
+        }
+      });
+    }
+
+    if (operations.length === 0) {
+      return res.json({ ok: true, count: 0 });
+    }
+
+    const result = await Question.bulkWrite(operations, { ordered: false });
+    const insertedCount = result.upsertedCount || 0;
+
+    return res.json({ ok: true, count: insertedCount });
+  } catch (error) {
+    if (error?.statusCode === 400) {
+      return res.status(400).json({ ok: false, message: error.message });
+    }
+    return next(error);
+  }
+});
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- add configuration and provider utilities for The Trivia API
- expose an admin import route that writes questions with checksum-based deduplication
- allow question filtering for the new trivia source

## Testing
- node -e "require('./src/providers/thetrivia'); require('./src/routes/trivia-triviaapi');"


------
https://chatgpt.com/codex/tasks/task_e_68cbf45e1ed48326a8b9c5a2d1be0a7b