### PR TITLE
Fix optional chaining assignment error

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -2167,8 +2167,10 @@ patchPricingKeys(RemoteConfig);
       packs.forEach(p=>{
         const card = document.querySelector(`[data-buy-key="${p.id}"]`);
         if (!card) return;
-        card.querySelector('[data-amount]')?.textContent = faNum(p.amount);
-        card.querySelector('[data-price]')?.textContent  = faNum(p.priceGame);
+        const amountEl = card.querySelector('[data-amount]');
+        if (amountEl) amountEl.textContent = faNum(p.amount);
+        const priceEl = card.querySelector('[data-price]');
+        if (priceEl) priceEl.textContent = faNum(p.priceGame);
         card.disabled = false;
       });
       $$('.product-card[data-buy-key]').forEach(card=>{


### PR DESCRIPTION
## Summary
- guard optional chained DOM assignments in IQuiz-bot.html so they only execute when elements exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc0d98b0b88326a13a8a1bedf381cd