### PR TITLE
Fix optional chaining assignment for setup count

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -3300,9 +3300,10 @@ function openCreateGroup(){
     closeSheet();
     navTo('duel');
   });
-  document.getElementById('range-count')?.addEventListener('input', e=>{
-    document.getElementById('setup-count')?.textContent = faNum(e.target.value);
-  });
+    document.getElementById('range-count')?.addEventListener('input', e=>{
+      var setupCountEl = document.getElementById('setup-count');
+      if (setupCountEl) setupCountEl.textContent = faNum(e.target.value);
+    });
 
 async function startQuizFromAdmin(arg) {
   // اگر از روی فرم صدا زده شده باشد


### PR DESCRIPTION
## Summary
- replace optional chaining assignment when updating the setup count display
- guard the textContent update by storing the element and checking for its existence first

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc1014394c83268bdf460cf558a1ba