### PR TITLE
Improve admin question management workflows

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -194,6 +194,62 @@
       cursor: progress;
       pointer-events: none;
     }
+    .toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      cursor: pointer;
+      user-select: none;
+    }
+    .toggle input[type="checkbox"] {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 48px;
+      height: 26px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.18);
+      border: 1px solid rgba(255,255,255,0.25);
+      position: relative;
+      transition: all 0.25s ease;
+      box-shadow: inset 0 6px 18px rgba(15,23,42,0.35);
+    }
+    .toggle input[type="checkbox"]::before {
+      content: '';
+      position: absolute;
+      top: 1px;
+      right: 1px;
+      width: 22px;
+      height: 22px;
+      border-radius: 999px;
+      background: #fff;
+      box-shadow: 0 6px 18px rgba(15,23,42,0.25);
+      transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+    }
+    .toggle input[type="checkbox"]:checked {
+      background: linear-gradient(135deg, var(--accent1), var(--accent2));
+      border-color: transparent;
+      box-shadow: 0 12px 30px rgba(59,130,246,0.35);
+    }
+    .toggle input[type="checkbox"]:checked::before {
+      transform: translateX(-22px);
+      background: #0f172a;
+      box-shadow: 0 6px 16px rgba(15,23,42,0.45);
+    }
+    .toggle input[type="checkbox"]:focus-visible {
+      outline: 2px solid rgba(59,130,246,0.75);
+      outline-offset: 3px;
+    }
+    .toggle .toggle-label {
+      font-weight: 800;
+      color: #fff;
+      line-height: 1.4;
+    }
+    .toggle .toggle-helper {
+      display: block;
+      font-size: 0.75rem;
+      color: rgba(255,255,255,0.65);
+      line-height: 1.6;
+    }
     .category-scroll::-webkit-scrollbar {
       width: 6px;
     }
@@ -2476,6 +2532,32 @@
             <label class="block text-sm mb-2 font-semibold text-white/80">متن کامل سوال</label>
             <textarea name="question-text" class="form-input min-h-[140px] text-sm leading-relaxed" placeholder="متن سوال را وارد کنید..."></textarea>
           </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label class="block text-sm mb-2 font-semibold text-white/80" for="question-detail-category">دسته‌بندی</label>
+              <select id="question-detail-category" class="form-select"></select>
+              <p class="text-xs text-white/60 mt-2 leading-6">دسته‌بندی تعیین می‌کند که سوال در کدام بخش ربات نمایش داده شود.</p>
+            </div>
+            <div>
+              <label class="block text-sm mb-2 font-semibold text-white/80" for="question-detail-difficulty">سطح دشواری</label>
+              <select id="question-detail-difficulty" class="form-select">
+                <option value="easy">آسون</option>
+                <option value="medium">متوسط</option>
+                <option value="hard">سخت</option>
+              </select>
+              <p class="text-xs text-white/60 mt-2 leading-6">با انتخاب سطح دشواری می‌توانید مسیر پیشروی کاربران را مدیریت کنید.</p>
+            </div>
+            <div class="glass-dark rounded-2xl border border-white/10 px-4 py-4 space-y-3">
+              <span class="text-sm font-semibold text-white/80">وضعیت سوال</span>
+              <label class="toggle w-full" for="question-detail-active">
+                <input type="checkbox" id="question-detail-active" />
+                <div>
+                  <span class="toggle-label">فعال باشد</span>
+                  <span class="toggle-helper">در صورت غیرفعال شدن، سوال از IQuiz-Bot حذف می‌شود.</span>
+                </div>
+              </label>
+            </div>
+          </div>
           <div class="space-y-3">
             <div class="flex items-center justify-between">
               <label class="block text-sm font-semibold text-white/80">گزینه‌ها</label>
@@ -2518,31 +2600,37 @@
       </div>
       <div class="modal-body">
         <div class="field-group">
-          <label>متن سوال</label>
-          <textarea class="form-input min-h-[130px] text-sm leading-relaxed" rows="4" placeholder="متن سوال را وارد کنید..."></textarea>
+          <label for="add-question-text">متن سوال</label>
+          <textarea id="add-question-text" class="form-input min-h-[130px] text-sm leading-relaxed" rows="4" placeholder="متن سوال را وارد کنید..."></textarea>
           <span class="helper-text">برای وضوح بیشتر، سوال را کوتاه و دقیق بنویسید.</span>
         </div>
         <div class="select-grid">
           <div class="field-group">
-            <label>دسته‌بندی</label>
-            <select class="form-select">
-              <option>عمومی</option>
-              <option>جغرافیا</option>
-              <option>ورزش</option>
-              <option>علم</option>
-              <option>تاریخ</option>
-              <option>هنر</option>
-              <option>سرگرمی</option>
+            <label for="add-question-category">دسته‌بندی</label>
+            <select id="add-question-category" class="form-select">
+              <option value="">دسته‌بندی مورد نظر را انتخاب کنید</option>
             </select>
+            <span class="helper-text">دسته‌بندی مشخص می‌کند سوال در کدام بخش ربات نمایش داده شود.</span>
           </div>
           <div class="field-group">
-            <label>سطح دشواری</label>
-            <select class="form-select">
-              <option>آسون</option>
-              <option>متوسط</option>
-              <option>سخت</option>
+            <label for="add-question-difficulty">سطح دشواری</label>
+            <select id="add-question-difficulty" class="form-select">
+              <option value="easy">آسون</option>
+              <option value="medium">متوسط</option>
+              <option value="hard">سخت</option>
             </select>
+            <span class="helper-text">سطح دشواری روی امتیاز و تجربه کاربران تاثیر می‌گذارد.</span>
           </div>
+        </div>
+        <div class="field-group">
+          <span class="field-label">وضعیت سوال</span>
+          <label class="toggle" for="add-question-active">
+            <input type="checkbox" id="add-question-active" checked />
+            <div>
+              <span class="toggle-label">سوال فعال باشد</span>
+              <span class="toggle-helper">در صورت غیرفعال بودن، سوال به کاربران IQuiz-Bot نمایش داده نمی‌شود.</span>
+            </div>
+          </label>
         </div>
         <div class="field-group">
           <div class="flex items-center justify-between gap-2 flex-wrap">
@@ -2551,19 +2639,19 @@
           </div>
           <div class="options-wrapper">
             <div class="option-row">
-              <input type="radio" name="correct-answer">
+              <input type="radio" name="correct-answer" value="0">
               <input type="text" class="form-input" placeholder="گزینه ۱">
             </div>
             <div class="option-row">
-              <input type="radio" name="correct-answer">
+              <input type="radio" name="correct-answer" value="1">
               <input type="text" class="form-input" placeholder="گزینه ۲">
             </div>
             <div class="option-row">
-              <input type="radio" name="correct-answer">
+              <input type="radio" name="correct-answer" value="2">
               <input type="text" class="form-input" placeholder="گزینه ۳">
             </div>
             <div class="option-row">
-              <input type="radio" name="correct-answer">
+              <input type="radio" name="correct-answer" value="3">
               <input type="text" class="form-input" placeholder="گزینه ۴">
             </div>
           </div>

--- a/server/src/controllers/questions.controller.js
+++ b/server/src/controllers/questions.controller.js
@@ -3,24 +3,64 @@ const Category = require('../models/Category');
 
 exports.create = async (req, res, next) => {
   try {
-    const { text, options, correctIdx, difficulty, categoryId } = req.body;
+    const { text, options, correctIdx, difficulty, categoryId, active, lang } = req.body;
+
+    const trimmedText = typeof text === 'string' ? text.trim() : '';
+    if (!trimmedText) {
+      return res.status(400).json({ ok: false, message: 'Question text is required' });
+    }
 
     if (!Array.isArray(options) || options.length !== 4) {
-      return res.status(400).json({ ok:false, message:'options must be array of 4 strings' });
+      return res.status(400).json({ ok: false, message: 'options must be array of 4 strings' });
     }
-    const category = await Category.findById(categoryId);
-    if (!category) return res.status(404).json({ ok:false, message:'Category not found' });
+
+    const normalizedOptions = options.map((choice) => String(choice ?? '').trim());
+    if (normalizedOptions.some((choice) => choice.length === 0)) {
+      return res.status(400).json({ ok: false, message: 'All options must be non-empty strings' });
+    }
+
+    const idx = Number(correctIdx);
+    if (!Number.isInteger(idx) || idx < 0 || idx > 3) {
+      return res.status(400).json({ ok: false, message: 'correctIdx must be between 0 and 3' });
+    }
+
+    if (!categoryId) {
+      return res.status(400).json({ ok: false, message: 'categoryId is required' });
+    }
+
+    let category;
+    try {
+      category = await Category.findById(categoryId);
+    } catch (error) {
+      if (error?.name === 'CastError') {
+        return res.status(400).json({ ok: false, message: 'Invalid categoryId' });
+      }
+      throw error;
+    }
+    if (!category) {
+      return res.status(404).json({ ok: false, message: 'Category not found' });
+    }
+
+    const difficultyKey = typeof difficulty === 'string' ? difficulty.toLowerCase() : 'easy';
+    const allowedDifficulties = ['easy', 'medium', 'hard'];
+    const safeDifficulty = allowedDifficulties.includes(difficultyKey) ? difficultyKey : 'easy';
+    const isActive = typeof active === 'boolean' ? active : true;
+    const detectedLang = typeof lang === 'string' && lang.trim() ? lang.trim() : 'fa';
 
     const q = await Question.create({
-      text,
-      options,
-      correctIdx,
-      difficulty: difficulty || 'easy',
-      category: categoryId,
+      text: trimmedText,
+      options: normalizedOptions,
+      choices: normalizedOptions,
+      correctIdx: idx,
+      correctIndex: idx,
+      difficulty: safeDifficulty,
+      category: category._id,
       categoryName: category.name,
+      active: isActive,
+      lang: detectedLang,
       source: 'manual'
     });
-    res.status(201).json({ ok:true, data:q });
+    res.status(201).json({ ok: true, data: q });
   } catch (e) { next(e); }
 };
 
@@ -52,8 +92,77 @@ exports.list = async (req, res, next) => {
 
 exports.update = async (req, res, next) => {
   try {
-    const updated = await Question.findByIdAndUpdate(req.params.id, req.body, { new:true });
-    res.json({ ok:true, data:updated });
+    const { text, options, correctIdx, difficulty, active } = req.body;
+    const updates = {};
+
+    if (typeof text === 'string' && text.trim()) {
+      updates.text = text.trim();
+    }
+
+    if (Array.isArray(options)) {
+      if (options.length !== 4) {
+        return res.status(400).json({ ok: false, message: 'options must be array of 4 strings' });
+      }
+      const normalizedOptions = options.map((choice) => String(choice ?? '').trim());
+      if (normalizedOptions.some((choice) => choice.length === 0)) {
+        return res.status(400).json({ ok: false, message: 'All options must be non-empty strings' });
+      }
+      updates.options = normalizedOptions;
+      updates.choices = normalizedOptions;
+    }
+
+    if (correctIdx !== undefined) {
+      const idx = Number(correctIdx);
+      if (!Number.isInteger(idx) || idx < 0 || idx > 3) {
+        return res.status(400).json({ ok: false, message: 'correctIdx must be between 0 and 3' });
+      }
+      updates.correctIdx = idx;
+      updates.correctIndex = idx;
+    }
+
+    if (typeof difficulty === 'string') {
+      const difficultyKey = difficulty.toLowerCase();
+      const allowedDifficulties = ['easy', 'medium', 'hard'];
+      if (!allowedDifficulties.includes(difficultyKey)) {
+        return res.status(400).json({ ok: false, message: 'Invalid difficulty' });
+      }
+      updates.difficulty = difficultyKey;
+    }
+
+    if (typeof active === 'boolean') {
+      updates.active = active;
+    }
+
+    let categoryCandidate = req.body.categoryId;
+    if (!categoryCandidate && typeof req.body.category === 'string') {
+      categoryCandidate = req.body.category;
+    }
+    if (!categoryCandidate && req.body.category && typeof req.body.category._id === 'string') {
+      categoryCandidate = req.body.category._id;
+    }
+
+    if (categoryCandidate) {
+      let category;
+      try {
+        category = await Category.findById(categoryCandidate);
+      } catch (error) {
+        if (error?.name === 'CastError') {
+          return res.status(400).json({ ok: false, message: 'Invalid categoryId' });
+        }
+        throw error;
+      }
+      if (!category) {
+        return res.status(404).json({ ok: false, message: 'Category not found' });
+      }
+      updates.category = category._id;
+      updates.categoryName = category.name;
+    }
+
+    const updated = await Question.findByIdAndUpdate(req.params.id, updates, { new: true });
+    if (!updated) {
+      return res.status(404).json({ ok: false, message: 'Question not found' });
+    }
+    res.json({ ok: true, data: updated });
   } catch (e) { next(e); }
 };
 


### PR DESCRIPTION
## Summary
- expand the admin question detail and add question modals with category, difficulty, and active state controls
- implement cached category handling, question CRUD flows, and UI refresh logic in the admin panel script
- harden the question controller to validate inputs and persist alias-backed fields when creating or updating questions

## Testing
- No automated tests (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc439b26e4832690a5e912da0bdb5c