### PR TITLE
Add ads management backend and update client rendering

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -194,6 +194,16 @@
       cursor: progress;
       pointer-events: none;
     }
+    .province-chip {
+      padding: 0.4rem 0.85rem;
+      font-size: 0.8rem;
+    }
+    .province-chip span {
+      pointer-events: none;
+    }
+    .province-chip input {
+      display: none;
+    }
     .toggle {
       display: inline-flex;
       align-items: center;
@@ -1111,6 +1121,12 @@
             </a>
           </li>
           <li>
+            <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="ads">
+              <i class="fa-solid fa-bullhorn"></i>
+              <span>مدیریت تبلیغات</span>
+            </a>
+          </li>
+          <li>
             <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="achievements">
               <i class="fa-solid fa-medal"></i>
               <span>مدیریت دستاوردها</span>
@@ -1175,6 +1191,12 @@
           <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="analytics">
             <i class="fa-solid fa-chart-bar"></i>
             <span>تحلیل داده‌ها</span>
+          </a>
+        </li>
+        <li>
+          <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="ads">
+            <i class="fa-solid fa-bullhorn"></i>
+            <span>مدیریت تبلیغات</span>
           </a>
         </li>
         <li>
@@ -2058,8 +2080,101 @@
                 </div>
                 <div class="text-sm opacity-80">۶۵ بازی</div>
               </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ADS MANAGEMENT -->
+      <section id="page-ads" class="hidden space-y-6">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 class="text-2xl font-bold">مدیریت تبلیغات</h1>
+            <p class="text-sm text-white/70 mt-1">کمپین‌های بنری، همسان و ویدیویی را از یک داشبورد واحد برنامه‌ریزی و کنترل کنید.</p>
+          </div>
+          <button id="btn-add-ad" class="btn btn-primary w-auto px-5">
+            <i class="fa-solid fa-plus ml-2"></i>
+            تبلیغ جدید
+          </button>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+          <div class="glass rounded-2xl p-4 flex flex-col gap-2">
+            <div class="flex items-center justify-between text-sm text-white/70">
+              <span>کل کمپین‌ها</span>
+              <i class="fa-solid fa-layer-group text-white/60"></i>
+            </div>
+            <div class="text-3xl font-extrabold" data-ads-stat="total">۰</div>
+            <p class="text-xs text-white/60">تمام تبلیغات ثبت‌شده در سیستم</p>
+          </div>
+          <div class="glass rounded-2xl p-4 flex flex-col gap-2">
+            <div class="flex items-center justify-between text-sm text-emerald-200/90">
+              <span>در حال نمایش</span>
+              <i class="fa-solid fa-signal"></i>
+            </div>
+            <div class="text-3xl font-extrabold text-emerald-300" data-ads-stat="active">۰</div>
+            <p class="text-xs text-white/60">کمپین‌هایی که همین حالا برای کاربران فعال هستند</p>
+          </div>
+          <div class="glass rounded-2xl p-4 flex flex-col gap-2">
+            <div class="flex items-center justify-between text-sm text-amber-200/90">
+              <span>زمان‌بندی‌شده</span>
+              <i class="fa-solid fa-clock"></i>
+            </div>
+            <div class="text-3xl font-extrabold text-amber-300" data-ads-stat="scheduled">۰</div>
+            <p class="text-xs text-white/60">کمپین‌هایی که هنوز شروع نشده‌اند</p>
+          </div>
+          <div class="glass rounded-2xl p-4 flex flex-col gap-2">
+            <div class="flex items-center justify-between text-sm text-rose-200/90">
+              <span>متوقف / منقضی</span>
+              <i class="fa-solid fa-power-off"></i>
+            </div>
+            <div class="text-3xl font-extrabold text-rose-300" data-ads-stat="inactive">۰</div>
+            <p class="text-xs text-white/60">کمپین‌های پایان‌یافته یا در حالت توقف</p>
+          </div>
+        </div>
+
+        <div class="glass rounded-2xl p-4 flex flex-col gap-4">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="flex flex-wrap gap-2" id="ads-placement-filters">
+              <button type="button" class="chip-toggle active" data-ads-filter-placement="all">همه جایگاه‌ها</button>
+              <button type="button" class="chip-toggle" data-ads-filter-placement="banner">بنری</button>
+              <button type="button" class="chip-toggle" data-ads-filter-placement="native">همسان</button>
+              <button type="button" class="chip-toggle" data-ads-filter-placement="interstitial">میانی</button>
+              <button type="button" class="chip-toggle" data-ads-filter-placement="rewarded">ویدیویی پاداش‌دار</button>
+            </div>
+            <div class="flex flex-wrap gap-2" id="ads-status-filters">
+              <button type="button" class="chip-toggle active" data-ads-filter-status="all">همه وضعیت‌ها</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="active">فعال</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="scheduled">زمان‌بندی‌شده</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="paused">متوقف</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="expired">منقضی</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="draft">پیش‌نویس</button>
+              <button type="button" class="chip-toggle" data-ads-filter-status="archived">آرشیو</button>
             </div>
           </div>
+          <div class="relative">
+            <input type="search" id="ads-search" class="form-input pr-10" placeholder="جستجوی سریع بین کمپین‌ها...">
+            <i class="fa-solid fa-search absolute right-3 top-1/2 -translate-y-1/2 text-white/40"></i>
+          </div>
+        </div>
+
+        <div id="ads-loading-state" class="glass rounded-2xl p-5 flex items-center gap-3 hidden">
+          <span class="w-4 h-4 border-2 border-white/40 border-t-transparent rounded-full animate-spin"></span>
+          <span class="text-sm text-white/80">در حال دریافت لیست تبلیغات...</span>
+        </div>
+
+        <div id="ads-empty-state" class="glass rounded-2xl p-8 text-center hidden">
+          <div class="mx-auto w-16 h-16 rounded-2xl bg-white/10 border border-white/10 flex items-center justify-center mb-4">
+            <i class="fa-solid fa-bullhorn text-2xl text-white/80"></i>
+          </div>
+          <h3 class="text-xl font-bold mb-2">هیچ تبلیغی ثبت نشده است</h3>
+          <p class="text-sm text-white/70 mb-6">برای شروع، اولین کمپین خود را ایجاد کنید تا تبلیغات در IQuiz-Bot نمایش داده شود.</p>
+          <button type="button" class="btn btn-secondary w-auto px-6" data-action="open-ad-modal">
+            <i class="fa-solid fa-plus ml-2"></i>
+            ساخت کمپین جدید
+          </button>
+        </div>
+
+        <div id="ads-grid" class="grid grid-cols-1 xl:grid-cols-2 gap-6"></div>
       </section>
 
       <!-- ACHIEVEMENTS MANAGEMENT -->
@@ -2386,6 +2501,114 @@
       </div>
     </div>
   </div>
+  <!-- Ad Modal -->
+  <div id="ad-modal" class="modal">
+    <div class="glass rounded-3xl p-6 max-w-3xl w-full mx-4 modal-content">
+      <div class="flex items-center justify-between gap-3 flex-wrap mb-4">
+        <div>
+          <h3 class="text-xl font-extrabold" data-ad-modal-title>ایجاد تبلیغ جدید</h3>
+          <p class="text-sm text-white/70" data-ad-modal-description>فرم زیر را تکمیل کنید تا تبلیغ در جایگاه‌های انتخابی نمایش داده شود.</p>
+        </div>
+        <button class="close-modal w-9 h-9 rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors">
+          <i class="fa-solid fa-times"></i>
+        </button>
+      </div>
+      <form id="ad-form" class="space-y-5">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm mb-1">نام کمپین</label>
+            <input type="text" id="ad-name" class="form-input" placeholder="مثال: کمپین زمستانه فروشگاه" required>
+          </div>
+          <div>
+            <label class="block text-sm mb-1">جایگاه نمایش</label>
+            <select id="ad-placement-select" class="form-select">
+              <option value="banner">بنر ثابت (۳۲۰×۱۰۰)</option>
+              <option value="native">تبلیغ همسان داشبورد</option>
+              <option value="interstitial">تبلیغ میانی تمام‌صفحه</option>
+              <option value="rewarded">ویدیویی پاداش‌دار</option>
+            </select>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm mb-1">وضعیت کمپین</label>
+            <select id="ad-status" class="form-select">
+              <option value="active">فعال</option>
+              <option value="paused">متوقف</option>
+              <option value="draft">پیش‌نویس</option>
+              <option value="archived">آرشیو</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm mb-1">اولویت نمایش</label>
+            <input type="number" id="ad-priority" class="form-input" min="0" max="100" value="1">
+            <span class="helper-text">عدد بالاتر یعنی نمایش بیشتر نسبت به سایر کمپین‌ها.</span>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm mb-1">تاریخ شروع</label>
+            <input type="date" id="ad-start-date" class="form-input" required>
+          </div>
+          <div>
+            <label class="block text-sm mb-1">تاریخ پایان</label>
+            <input type="date" id="ad-end-date" class="form-input" required>
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm mb-1">آدرس رسانه</label>
+          <input type="url" id="ad-creative-url" class="form-input" placeholder="https://example.com/banner.jpg" required>
+          <span class="helper-text" data-ad-helper="creative">برای بنر و همسان تصویر JPG/PNG، برای ویدیویی لینک فایل MP4 و برای میانی لینک صفحه فرود (HTTPS).</span>
+        </div>
+        <div data-show-placements="banner,native,rewarded">
+          <label class="block text-sm mb-1">لینک مقصد</label>
+          <input type="url" id="ad-landing-url" class="form-input" placeholder="https://example.com">
+          <span class="helper-text">کاربر پس از کلیک روی تبلیغ به این آدرس هدایت می‌شود.</span>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4" data-show-placements="native">
+          <div>
+            <label class="block text-sm mb-1">عنوان تبلیغ همسان</label>
+            <input type="text" id="ad-headline" class="form-input" placeholder="مثال: ۵۰٪ تخفیف فقط امروز">
+          </div>
+          <div>
+            <label class="block text-sm mb-1">متن دکمه</label>
+            <input type="text" id="ad-cta" class="form-input" placeholder="مشاهده" value="مشاهده">
+          </div>
+        </div>
+        <div data-show-placements="native">
+          <label class="block text-sm mb-1">توضیح کوتاه</label>
+          <textarea id="ad-description" class="form-input" rows="2" placeholder="توضیحی درباره پیشنهاد یا برند"></textarea>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4" data-show-placements="rewarded">
+          <div>
+            <label class="block text-sm mb-1">نوع پاداش</label>
+            <select id="ad-reward-type" class="form-select">
+              <option value="coins">سکه</option>
+              <option value="life">جان اضافه</option>
+              <option value="custom">سفارشی</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm mb-1">مقدار پاداش</label>
+            <input type="number" id="ad-reward-amount" class="form-input" min="1" max="1000" value="20">
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm mb-2">استان‌های هدف</label>
+          <div id="ad-province-options" class="flex flex-wrap gap-2 max-h-40 overflow-y-auto p-2 rounded-2xl bg-white/5 border border-white/10"></div>
+          <span class="helper-text">در صورت عدم انتخاب، تبلیغ در تمام استان‌ها نمایش داده می‌شود.</span>
+        </div>
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <p class="text-xs text-white/60">پس از ذخیره، کمپین در لیست تبلیغات قابل مدیریت است.</p>
+          <div class="flex gap-2">
+            <button type="button" class="btn btn-secondary close-modal">انصراف</button>
+            <button type="submit" id="ad-submit-btn" class="btn btn-primary w-auto px-6">ذخیره تبلیغ</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <!-- Add Question Modal -->
   <!-- Question Detail Modal -->
   <div id="question-detail-modal" class="modal">

--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -4573,16 +4573,17 @@ async function startPurchaseCoins(pkgId){
       }
       // Try remote, else fallback card
       try{
-        const res = await Net.jget('/api/ads?placement=banner&province='+encodeURIComponent(Server.user.province||State.user.province));
-        if(res && res.html){
-          const w = document.createElement('div'); w.className='w-full h-full relative';
-          w.innerHTML = res.html;
+        const res = await Net.jget('/api/public/ads?placement=banner&province='+encodeURIComponent(Server.user.province||State.user.province));
+        const data = res?.data ?? res;
+        if(data && data.creativeUrl){
+          const link = document.createElement('a'); link.className='w-full h-full block relative'; link.href = data.landingUrl || '#'; link.target = '_blank';
+          link.innerHTML = `<img src="${data.creativeUrl}" alt="sponsor banner" class="w-full h-full object-cover">`;
           const close = document.createElement('button'); close.className='ad-close'; close.innerHTML='<i class="fas fa-times"></i>'; close.setAttribute('aria-label','بستن بنر');
           close.onclick=()=>{ slot.innerHTML=`<div class="ad-skeleton">بنر بسته شد</div>`; logEvent('ad_close',{placement:'banner'}); };
-          w.appendChild(close);
-          slot.appendChild(w);
+          link.appendChild(close);
+          slot.appendChild(link);
           logEvent('ad_impression',{placement:'banner'});
-          w.addEventListener('click',()=>logEvent('ad_click',{placement:'banner'}),{once:true});
+          link.addEventListener('click',()=>logEvent('ad_click',{placement:'banner'}),{once:true});
           return;
         }
       }catch{}
@@ -4616,18 +4617,24 @@ async function startPurchaseCoins(pkgId){
       }
       if(!this.enabled() || !RemoteConfig.ads.placements.native){ slot.innerHTML = '<div class="ad-skeleton">—</div>'; return; }
       try{
-        const res = await Net.jget('/api/ads?placement=native&province='+encodeURIComponent(Server.user.province||State.user.province));
-        if(res && res.title){
-          slot.innerHTML = `<div class="w-full flex items-center gap-3 p-3">
-            <img src="${res.image||'https://picsum.photos/seed/ad/88/88'}" class="w-16 h-16 rounded-2xl object-cover" alt="ad">
+        const res = await Net.jget('/api/public/ads?placement=native&province='+encodeURIComponent(Server.user.province||State.user.province));
+        const data = res?.data ?? res;
+        if(data && (data.headline || data.imageUrl || data.landingUrl)){
+          const headline = data.headline || 'پیشنهاد ویژه';
+          const description = data.description || 'اسپانسر رسمی رقابت امروز';
+          const imageUrl = data.imageUrl || 'https://picsum.photos/seed/iquiz-native/88/88';
+          const landingUrl = data.landingUrl || '#';
+          const ctaLabel = data.ctaLabel || 'مشاهده';
+          slot.innerHTML = `<div class="w-full flex items-center gap-3 p-3 relative">
+            <img src="${imageUrl}" class="w-16 h-16 rounded-2xl object-cover" alt="ad">
             <div class="flex-1">
-              <div class="font-bold">${res.title}</div>
-              <div class="text-xs opacity-80">${res.desc||'پیشنهاد ویژه امروز'}</div>
+              <div class="font-bold">${headline}</div>
+              <div class="text-xs opacity-80">${description}</div>
             </div>
-            <a role="button" href="${res.ctaUrl||'#'}" class="btn btn-primary w-auto px-4 py-2 text-sm" aria-label="مشاهده">مشاهده</a>
+            <a role="button" href="${landingUrl}" target="_blank" rel="noopener" class="btn btn-primary w-auto px-4 py-2 text-sm" aria-label="${ctaLabel}">${ctaLabel}</a>
           </div>`;
           logEvent('ad_impression',{placement:'native'});
-          slot.querySelector('a')?.addEventListener('click', ()=>logEvent('ad_click',{placement:'native'}), {once:true});
+          slot.querySelector('a')?.addEventListener('click',()=>logEvent('ad_click',{placement:'native'}),{once:true});
           return;
         }
       }catch{}
@@ -4647,15 +4654,34 @@ async function startPurchaseCoins(pkgId){
       const local = this.getLocalAd('interstitial');
       logEvent('ad_impression',{placement:'interstitial', trigger, local:!!local});
       if(local){
+        frame.removeAttribute('srcdoc');
         frame.src = local.creative;
       } else {
-        let url = null; try{ const res = await Net.jget('/api/ads?placement=interstitial&province='+encodeURIComponent(Server.user.province||State.user.province)); url = res?.url||null; }catch{}
-        frame.src = url || 'about:blank';
-        if(!url){ frame.srcdoc = `<style>body{margin:0;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-family:sans-serif}</style><div>تبلیغ محلی</div>`; }
+        let remote = null;
+        try{
+          const res = await Net.jget('/api/public/ads?placement=interstitial&province='+encodeURIComponent(Server.user.province||State.user.province));
+          remote = res?.data ?? res;
+        }catch{}
+        const creativeUrl = remote?.creativeUrl ? String(remote.creativeUrl) : '';
+        const creativeType = (remote?.creativeType || '').toLowerCase();
+        if(creativeType === 'html' && creativeUrl){
+          frame.removeAttribute('src');
+          frame.srcdoc = creativeUrl;
+        } else if(creativeUrl && creativeUrl.trim().startsWith('<')){
+          frame.removeAttribute('src');
+          frame.srcdoc = creativeUrl;
+        } else if(creativeUrl){
+          frame.removeAttribute('srcdoc');
+          frame.src = creativeUrl;
+        } else {
+          frame.removeAttribute('src');
+          frame.src = 'about:blank';
+          frame.srcdoc = `<style>body{margin:0;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-family:sans-serif}</style><div>تبلیغ محلی</div>`;
+        }
       }
       modal.classList.add('show');
       let closed=false;
-      function close(){ if(closed) return; closed=true; modal.classList.remove('show'); frame.src='about:blank'; logEvent('ad_close',{placement:'interstitial'}); }
+      function close(){ if(closed) return; closed=true; modal.classList.remove('show'); frame.src='about:blank'; frame.removeAttribute('srcdoc'); logEvent('ad_close',{placement:'interstitial'}); }
       $('#interstitial-close').onclick = close;
       setTimeout(()=>{ if(!closed){ close(); } }, 10_000);
     },
@@ -4667,17 +4693,29 @@ async function startPurchaseCoins(pkgId){
       sess.rewardedShown++;
       const modal = $('#modal-rewarded'); const vid = $('#rewarded-video'); const claim = $('#rewarded-claim'); const cd = $('#rewarded-countdown');
       const local = this.getLocalAd('rewarded');
-      let src = null;
+      let videoSrc = null; let rewardType = reward; let rewardAmount = amount; let landingUrl = '#';
       if(local){
-        src = local.creative;
+        videoSrc = local.creative;
+        if(local.reward){ rewardType = String(local.reward).toLowerCase(); }
+        if(Number.isFinite(Number(local.amount))){ rewardAmount = Number(local.amount); }
+        if(local.landing){ landingUrl = local.landing; }
       } else {
-        try{ const res = await Net.jget('/api/ads?placement=rewarded&province='+encodeURIComponent(Server.user.province||State.user.province)); src = res?.video||null; }catch{}
+        try{
+          const res = await Net.jget('/api/public/ads?placement=rewarded&province='+encodeURIComponent(Server.user.province||State.user.province));
+          const data = res?.data ?? res;
+          if(data){
+            if(data.videoUrl) videoSrc = data.videoUrl;
+            if(data.rewardType) rewardType = String(data.rewardType).toLowerCase();
+            if(Number.isFinite(Number(data.rewardAmount))) rewardAmount = Number(data.rewardAmount);
+            if(data.landingUrl) landingUrl = data.landingUrl;
+          }
+        }catch{}
       }
-      if(!src){
+      if(!videoSrc){
         vid.removeAttribute('src'); vid.querySelector('source').src=''; vid.load();
         cd.textContent = 'اسپانسر محلی — پخش نمادین';
       } else {
-        vid.querySelector('source').src = src; vid.load();
+        vid.querySelector('source').src = videoSrc; vid.load();
       }
       claim.disabled = true; let canClaimAt = Date.now()+RemoteConfig.ads.rewardedMinWatchMs;
       const t = setInterval(()=>{
@@ -4691,12 +4729,14 @@ async function startPurchaseCoins(pkgId){
         $('#rewarded-close').onclick=()=>{ logEvent('ad_close',{placement:'rewarded'}); cleanup(false); };
         claim.onclick=async ()=>{
           cleanup(true);
-          if(reward==='coins'){ State.coins += amount; renderTopBars(); saveState(); }
-          if(reward==='life'){ State.lives += 1; renderTopBars(); saveState(); }
-          await logEvent('ad_completed',{placement:'rewarded', reward, amount});
-          await logEvent('reward_granted',{reward, amount});
-          const rewardName = reward==='coins'?'سکه':'کلید';
-          toast(`<i class="fas fa-check ml-1"></i> پاداش دریافت شد: ${faNum(amount)} ${rewardName}`);
+          if(rewardType==='coins'){ State.coins += rewardAmount; renderTopBars(); saveState(); }
+          if(rewardType==='life'){ const livesToAdd = Math.max(1, Math.round(rewardAmount||1)); State.lives += livesToAdd; renderTopBars(); saveState(); }
+          await logEvent('ad_completed',{placement:'rewarded', reward:rewardType, amount:rewardAmount});
+          await logEvent('reward_granted',{reward:rewardType, amount:rewardAmount});
+          const rewardName = rewardType==='coins'?'سکه':(rewardType==='life'?'کلید':'پاداش');
+          toast(`<i class="fas fa-check ml-1"></i> پاداش دریافت شد: ${faNum(rewardAmount)} ${rewardName}`);
+          const safeLanding = typeof landingUrl==='string' && /^https?:\/\//i.test(landingUrl);
+          if(safeLanding){ setTimeout(()=>window.open(landingUrl,'_blank','noopener'),300); }
           SFX.coin();
         };
       });

--- a/server/src/controllers/ads.controller.js
+++ b/server/src/controllers/ads.controller.js
@@ -1,0 +1,319 @@
+const mongoose = require('mongoose');
+const AdModel = require('../models/Ad');
+const {
+  AD_PLACEMENTS,
+  AD_STATUSES,
+  AD_CREATIVE_TYPES,
+  AD_REWARD_TYPES
+} = AdModel;
+
+const Ad = AdModel;
+
+const PLACEMENTS = new Set(AD_PLACEMENTS);
+const STATUSES = new Set(AD_STATUSES);
+const CREATIVE_TYPES = new Set(AD_CREATIVE_TYPES);
+const REWARD_TYPES = new Set(AD_REWARD_TYPES);
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+function sanitizePlacement(value) {
+  const normalized = sanitizeString(value).toLowerCase();
+  return PLACEMENTS.has(normalized) ? normalized : '';
+}
+
+function sanitizeStatus(value, fallback = 'draft') {
+  const normalized = sanitizeString(value).toLowerCase();
+  if (!normalized) return fallback;
+  return STATUSES.has(normalized) ? normalized : fallback;
+}
+
+function sanitizeCreativeType(value, fallback = 'image') {
+  const normalized = sanitizeString(value).toLowerCase();
+  return CREATIVE_TYPES.has(normalized) ? normalized : fallback;
+}
+
+function sanitizeRewardType(value, fallback = 'coins') {
+  const normalized = sanitizeString(value).toLowerCase();
+  return REWARD_TYPES.has(normalized) ? normalized : fallback;
+}
+
+function sanitizeUrl(value, { allowEmpty = true } = {}) {
+  const url = sanitizeString(value);
+  if (!url) return allowEmpty ? '' : null;
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return allowEmpty ? '' : null;
+    return parsed.toString();
+  } catch (err) {
+    return allowEmpty ? '' : null;
+  }
+}
+
+function sanitizeNumber(value, { fallback = 0, min = Number.NEGATIVE_INFINITY, max = Number.POSITIVE_INFINITY, round = false } = {}) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  let normalized = num;
+  if (round) normalized = Math.round(normalized);
+  if (normalized < min) normalized = min;
+  if (normalized > max) normalized = max;
+  return normalized;
+}
+
+function sanitizeDate(value) {
+  const str = sanitizeString(value);
+  if (!str) return null;
+  const date = new Date(str);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function sanitizeProvinces(list) {
+  const values = Array.isArray(list) ? list : [];
+  const unique = new Set();
+  values.forEach((item) => {
+    const normalized = sanitizeString(item);
+    if (normalized) unique.add(normalized);
+  });
+  return Array.from(unique);
+}
+
+function mapAdDocument(doc) {
+  if (!doc) return null;
+  const raw = doc.toObject ? doc.toObject() : doc;
+  const id = raw._id ? String(raw._id) : null;
+  return {
+    id,
+    name: raw.name || '',
+    placement: raw.placement,
+    status: raw.status,
+    priority: raw.priority,
+    creativeUrl: raw.creativeUrl,
+    creativeType: raw.creativeType,
+    landingUrl: raw.landingUrl || '',
+    headline: raw.headline || '',
+    body: raw.body || '',
+    ctaLabel: raw.ctaLabel || '',
+    rewardType: raw.rewardType || 'coins',
+    rewardAmount: raw.rewardAmount ?? 0,
+    provinces: Array.isArray(raw.provinces) ? raw.provinces : [],
+    startDate: raw.startDate,
+    endDate: raw.endDate,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt
+  };
+}
+
+exports.create = async (req, res, next) => {
+  try {
+    const name = sanitizeString(req.body.name);
+    const placement = sanitizePlacement(req.body.placement);
+    const status = sanitizeStatus(req.body.status, 'active');
+    const creativeUrl = sanitizeUrl(req.body.creativeUrl, { allowEmpty: false });
+    const landingUrl = sanitizeUrl(req.body.landingUrl);
+    const creativeType = sanitizeCreativeType(req.body.creativeType, placement === 'rewarded' ? 'video' : placement === 'interstitial' ? 'html' : 'image');
+    const headline = sanitizeString(req.body.headline);
+    const body = sanitizeString(req.body.body);
+    const ctaLabel = sanitizeString(req.body.ctaLabel) || 'مشاهده';
+    const provinces = sanitizeProvinces(req.body.provinces);
+    const startDate = sanitizeDate(req.body.startDate);
+    const endDate = sanitizeDate(req.body.endDate);
+    const rewardType = sanitizeRewardType(req.body.rewardType, 'coins');
+    const rewardAmount = sanitizeNumber(req.body.rewardAmount, { fallback: 20, min: 0, max: 1000, round: true });
+    const priority = sanitizeNumber(req.body.priority, { fallback: 1, min: 0, max: 100, round: true });
+
+    if (!name) {
+      return res.status(400).json({ ok: false, message: 'نام تبلیغ الزامی است' });
+    }
+    if (!placement) {
+      return res.status(400).json({ ok: false, message: 'جایگاه تبلیغ نامعتبر است' });
+    }
+    if (!creativeUrl) {
+      return res.status(400).json({ ok: false, message: 'آدرس محتوای تبلیغ الزامی است' });
+    }
+    if (!startDate || !endDate) {
+      return res.status(400).json({ ok: false, message: 'بازه زمانی تبلیغ معتبر نیست' });
+    }
+    if (startDate.getTime() > endDate.getTime()) {
+      return res.status(400).json({ ok: false, message: 'تاریخ پایان باید بعد از تاریخ شروع باشد' });
+    }
+
+    if (['banner', 'native', 'rewarded'].includes(placement) && !landingUrl) {
+      return res.status(400).json({ ok: false, message: 'لینک مقصد برای این جایگاه الزامی است' });
+    }
+    if (placement === 'native' && !headline) {
+      return res.status(400).json({ ok: false, message: 'عنوان تبلیغ همسان را وارد کنید' });
+    }
+    if (placement === 'rewarded' && rewardAmount <= 0) {
+      return res.status(400).json({ ok: false, message: 'مقدار پاداش باید بزرگ‌تر از صفر باشد' });
+    }
+
+    const ad = await Ad.create({
+      name,
+      placement,
+      status,
+      creativeUrl,
+      landingUrl,
+      creativeType,
+      headline,
+      body,
+      ctaLabel,
+      provinces,
+      startDate,
+      endDate,
+      rewardType,
+      rewardAmount,
+      priority
+    });
+
+    res.status(201).json({ ok: true, data: mapAdDocument(ad) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.list = async (req, res, next) => {
+  try {
+    const page = sanitizeNumber(req.query.page, { fallback: 1, min: 1, max: 500, round: true });
+    const limit = sanitizeNumber(req.query.limit, { fallback: 50, min: 1, max: 200, round: true });
+    const skip = (page - 1) * limit;
+    const placement = sanitizePlacement(req.query.placement);
+    const status = sanitizeStatus(req.query.status, '');
+    const q = sanitizeString(req.query.q);
+
+    const where = {};
+    if (placement) where.placement = placement;
+    if (status) where.status = status;
+    if (q) {
+      where.name = { $regex: q, $options: 'i' };
+    }
+
+    const [items, total] = await Promise.all([
+      Ad.find(where).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+      Ad.countDocuments(where)
+    ]);
+
+    res.json({
+      ok: true,
+      data: items.map(mapAdDocument),
+      meta: { total, page, limit }
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.remove = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(404).json({ ok: false, message: 'Ad not found' });
+    }
+    await Ad.findByIdAndDelete(id);
+    res.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.update = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(404).json({ ok: false, message: 'Ad not found' });
+    }
+
+    const ad = await Ad.findById(id);
+    if (!ad) {
+      return res.status(404).json({ ok: false, message: 'Ad not found' });
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'name')) {
+      const name = sanitizeString(req.body.name);
+      if (!name) {
+        return res.status(400).json({ ok: false, message: 'نام تبلیغ نمی‌تواند خالی باشد' });
+      }
+      ad.name = name;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'placement')) {
+      const placement = sanitizePlacement(req.body.placement);
+      if (!placement) {
+        return res.status(400).json({ ok: false, message: 'جایگاه تبلیغ نامعتبر است' });
+      }
+      ad.placement = placement;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'status')) {
+      ad.status = sanitizeStatus(req.body.status, ad.status);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'creativeUrl')) {
+      const creativeUrl = sanitizeUrl(req.body.creativeUrl, { allowEmpty: false });
+      if (!creativeUrl) {
+        return res.status(400).json({ ok: false, message: 'آدرس محتوای تبلیغ الزامی است' });
+      }
+      ad.creativeUrl = creativeUrl;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'landingUrl')) {
+      ad.landingUrl = sanitizeUrl(req.body.landingUrl) || '';
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'creativeType')) {
+      ad.creativeType = sanitizeCreativeType(req.body.creativeType, ad.creativeType);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'headline')) {
+      ad.headline = sanitizeString(req.body.headline);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'body')) {
+      ad.body = sanitizeString(req.body.body);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'ctaLabel')) {
+      ad.ctaLabel = sanitizeString(req.body.ctaLabel) || ad.ctaLabel;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'provinces')) {
+      ad.provinces = sanitizeProvinces(req.body.provinces);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'startDate')) {
+      const start = sanitizeDate(req.body.startDate);
+      if (!start) {
+        return res.status(400).json({ ok: false, message: 'تاریخ شروع نامعتبر است' });
+      }
+      ad.startDate = start;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'endDate')) {
+      const end = sanitizeDate(req.body.endDate);
+      if (!end) {
+        return res.status(400).json({ ok: false, message: 'تاریخ پایان نامعتبر است' });
+      }
+      ad.endDate = end;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'priority')) {
+      ad.priority = sanitizeNumber(req.body.priority, { fallback: ad.priority, min: 0, max: 100, round: true });
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'rewardType')) {
+      ad.rewardType = sanitizeRewardType(req.body.rewardType, ad.rewardType);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'rewardAmount')) {
+      ad.rewardAmount = sanitizeNumber(req.body.rewardAmount, { fallback: ad.rewardAmount, min: 0, max: 1000, round: true });
+    }
+
+    if (ad.startDate && ad.endDate && ad.startDate.getTime() > ad.endDate.getTime()) {
+      return res.status(400).json({ ok: false, message: 'تاریخ پایان باید بعد از تاریخ شروع باشد' });
+    }
+
+    await ad.save();
+    res.json({ ok: true, data: mapAdDocument(ad) });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -92,6 +92,7 @@ app.use('/api/categories', require('./routes/categories.routes'));
 app.use('/api/questions', require('./routes/questions.routes'));
 app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/achievements', require('./routes/achievements.routes'));
+app.use('/api/ads', require('./routes/ads.routes'));
 app.use('/api/public', require('./routes/public.routes'));
 app.use('/api/trivia', triviaRoutes);
 app.use('/api', require('./routes/trivia-triviaapi'));

--- a/server/src/models/Ad.js
+++ b/server/src/models/Ad.js
@@ -1,0 +1,93 @@
+const mongoose = require('mongoose');
+
+const AD_PLACEMENTS = ['banner', 'native', 'interstitial', 'rewarded'];
+const AD_STATUSES = ['draft', 'active', 'paused', 'archived'];
+const AD_CREATIVE_TYPES = ['image', 'video', 'html', 'iframe'];
+const AD_REWARD_TYPES = ['coins', 'life', 'custom'];
+
+const AdSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 120
+  },
+  placement: {
+    type: String,
+    required: true,
+    enum: AD_PLACEMENTS
+  },
+  status: {
+    type: String,
+    enum: AD_STATUSES,
+    default: 'active'
+  },
+  priority: {
+    type: Number,
+    min: 0,
+    max: 100,
+    default: 1
+  },
+  creativeUrl: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  creativeType: {
+    type: String,
+    enum: AD_CREATIVE_TYPES,
+    default: 'image'
+  },
+  landingUrl: {
+    type: String,
+    trim: true
+  },
+  headline: {
+    type: String,
+    trim: true,
+    maxlength: 120
+  },
+  body: {
+    type: String,
+    trim: true,
+    maxlength: 500
+  },
+  ctaLabel: {
+    type: String,
+    trim: true,
+    maxlength: 40
+  },
+  rewardType: {
+    type: String,
+    enum: AD_REWARD_TYPES,
+    default: 'coins'
+  },
+  rewardAmount: {
+    type: Number,
+    min: 0,
+    max: 1000,
+    default: 20
+  },
+  provinces: {
+    type: [String],
+    default: []
+  },
+  startDate: {
+    type: Date,
+    required: true
+  },
+  endDate: {
+    type: Date,
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+AdSchema.index({ placement: 1, status: 1, startDate: 1, endDate: 1 });
+
+module.exports = mongoose.model('Ad', AdSchema);
+module.exports.AD_PLACEMENTS = AD_PLACEMENTS;
+module.exports.AD_STATUSES = AD_STATUSES;
+module.exports.AD_CREATIVE_TYPES = AD_CREATIVE_TYPES;
+module.exports.AD_REWARD_TYPES = AD_REWARD_TYPES;

--- a/server/src/routes/ads.routes.js
+++ b/server/src/routes/ads.routes.js
@@ -1,0 +1,11 @@
+const router = require('express').Router();
+const { protect, adminOnly } = require('../middleware/auth');
+const ctrl = require('../controllers/ads.controller');
+
+router.use(protect, adminOnly);
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/server/src/routes/public.routes.js
+++ b/server/src/routes/public.routes.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const logger = require('../config/logger');
 const Category = require('../models/Category');
 const Question = require('../models/Question');
+const AdModel = require('../models/Ad');
 const {
   getFallbackCategories,
   mapCategoryDocument,
@@ -15,11 +16,114 @@ const {
 } = require('../services/publicContent');
 
 const MAX_PUBLIC_QUESTIONS = 20;
+const AD_PLACEMENTS = new Set(AdModel.AD_PLACEMENTS || ['banner', 'native', 'interstitial', 'rewarded']);
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
 
 function sanitizeCount(raw) {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) return 5;
   return Math.min(Math.max(parsed, 1), MAX_PUBLIC_QUESTIONS);
+}
+
+function sanitizePlacement(value) {
+  const normalized = sanitizeString(value).toLowerCase();
+  return AD_PLACEMENTS.has(normalized) ? normalized : '';
+}
+
+function sanitizeProvince(value) {
+  return sanitizeString(value);
+}
+
+function isAdActive(ad, nowTs) {
+  if (!ad) return false;
+  if ((ad.status || '').toLowerCase() !== 'active') return false;
+  const start = ad.startDate ? new Date(ad.startDate).getTime() : null;
+  const end = ad.endDate ? new Date(ad.endDate).getTime() : null;
+  if (Number.isFinite(start) && start > nowTs) return false;
+  if (Number.isFinite(end) && end < nowTs) return false;
+  return true;
+}
+
+function matchesProvince(ad, province) {
+  if (!province) return true;
+  const list = Array.isArray(ad?.provinces) ? ad.provinces : [];
+  if (list.length === 0) return true;
+  const normalizedProvince = province.trim();
+  return list.some((item) => sanitizeString(item) === normalizedProvince);
+}
+
+function pickWeightedAd(ads) {
+  if (!Array.isArray(ads) || ads.length === 0) return null;
+  if (ads.length === 1) return ads[0];
+  const weights = ads.map((ad) => {
+    const priority = Number(ad.priority);
+    if (!Number.isFinite(priority) || priority <= 0) return 1;
+    return Math.min(Math.max(Math.round(priority), 1), 100);
+  });
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  const target = Math.random() * total;
+  let cumulative = 0;
+  for (let i = 0; i < ads.length; i += 1) {
+    cumulative += weights[i];
+    if (target <= cumulative) return ads[i];
+  }
+  return ads[ads.length - 1];
+}
+
+function mapAdForPublic(ad) {
+  if (!ad) return null;
+  const id = ad._id ? String(ad._id) : ad.id;
+  const placement = ad.placement;
+  const base = {
+    id,
+    placement,
+    startDate: ad.startDate,
+    endDate: ad.endDate
+  };
+
+  switch (placement) {
+    case 'banner':
+      return {
+        ...base,
+        creativeUrl: ad.creativeUrl,
+        creativeType: ad.creativeType || 'image',
+        landingUrl: ad.landingUrl || '',
+        ctaLabel: ad.ctaLabel || 'مشاهده'
+      };
+    case 'native':
+      return {
+        ...base,
+        creativeType: ad.creativeType || 'image',
+        headline: ad.headline || ad.name || '',
+        description: ad.body || '',
+        imageUrl: ad.creativeUrl,
+        landingUrl: ad.landingUrl || '',
+        ctaLabel: ad.ctaLabel || 'مشاهده'
+      };
+    case 'interstitial':
+      return {
+        ...base,
+        creativeUrl: ad.creativeUrl,
+        creativeType: ad.creativeType || 'html',
+        landingUrl: ad.landingUrl || ''
+      };
+    case 'rewarded':
+      return {
+        ...base,
+        videoUrl: ad.creativeUrl,
+        creativeType: ad.creativeType || 'video',
+        landingUrl: ad.landingUrl || '',
+        rewardType: ad.rewardType || 'coins',
+        rewardAmount: ad.rewardAmount ?? 0
+      };
+    default:
+      return {
+        ...base,
+        creativeUrl: ad.creativeUrl,
+        landingUrl: ad.landingUrl || ''
+      };
+  }
 }
 
 function buildCategoryMap(items) {
@@ -113,6 +217,33 @@ router.get('/questions', async (req, res) => {
   }
 
   return fallbackResponse();
+});
+
+router.get('/ads', async (req, res) => {
+  const placement = sanitizePlacement(req.query.placement);
+  if (!placement) {
+    return res.status(400).json({ ok: false, message: 'invalid placement' });
+  }
+  const province = sanitizeProvince(req.query.province || '');
+  const now = new Date();
+  const nowTs = now.getTime();
+
+  try {
+    const docs = await AdModel.find({
+      placement,
+      status: 'active',
+      startDate: { $lte: now },
+      endDate: { $gte: now }
+    }).sort({ priority: -1, updatedAt: -1 }).lean();
+
+    const eligible = docs.filter((ad) => isAdActive(ad, nowTs) && matchesProvince(ad, province));
+    const selected = pickWeightedAd(eligible);
+
+    res.json({ ok: true, data: mapAdForPublic(selected) });
+  } catch (error) {
+    logger.warn(`Failed to load ads for placement ${placement}: ${error.message}`);
+    res.json({ ok: true, data: null });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a responsive ads management area in the admin panel with stats, filters, and creation modal
- implement ads model, controller, and admin/public endpoints to manage creatives and targeting
- update IQuiz bot placements to consume the new ads API with creative type and reward handling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cda9d258f48326aa035f697dff83c8