### PR TITLE
Add province CRUD UI and backend with tests

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -1342,6 +1342,12 @@
             </a>
           </li>
           <li>
+            <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="provinces">
+              <i class="fa-solid fa-map-location-dot"></i>
+              <span>مدیریت استان‌ها</span>
+            </a>
+          </li>
+          <li>
             <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="users">
               <i class="fa-solid fa-users"></i>
               <span>مدیریت کاربران</span>
@@ -1412,6 +1418,12 @@
           <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="categories">
             <i class="fa-solid fa-th-large"></i>
             <span>مدیریت دسته‌بندی‌ها</span>
+          </a>
+        </li>
+        <li>
+          <a href="#" class="sidebar-item flex items-center gap-3 p-3 rounded-xl" data-page="provinces">
+            <i class="fa-solid fa-map-location-dot"></i>
+            <span>مدیریت استان‌ها</span>
           </a>
         </li>
         <li>
@@ -2313,6 +2325,109 @@
                 </div>
                 <div class="text-sm opacity-80">۶۵ بازی</div>
               </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- PROVINCE MANAGEMENT -->
+      <section id="page-provinces" class="hidden space-y-6">
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 class="text-2xl font-bold">مدیریت استان‌ها</h1>
+            <p class="text-sm text-white/70 mt-1">استان‌های فعال برای هدف‌گیری تبلیغات و گزارش‌های منطقه‌ای را مدیریت کنید.</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <button id="province-refresh-btn" class="btn btn-secondary w-auto px-4">
+              <i class="fa-solid fa-rotate ml-2"></i>
+              بروزرسانی فهرست
+            </button>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <div class="glass rounded-2xl p-6 space-y-5">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h2 id="province-form-title" class="text-xl font-bold">افزودن استان جدید</h2>
+                <p class="text-xs text-white/60 mt-1">نام استان را وارد کنید و وضعیت نمایش آن را مشخص نمایید.</p>
+              </div>
+              <span data-province-form-status class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 text-xs text-white/70">در حالت ایجاد</span>
+            </div>
+
+            <form id="province-form" class="space-y-4">
+              <div>
+                <label for="province-name" class="block text-sm mb-1">نام استان</label>
+                <input id="province-name" name="name" type="text" class="form-input" placeholder="مثلاً تهران" required />
+              </div>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label for="province-code" class="block text-sm mb-1">کد لاتین (اختیاری)</label>
+                  <input id="province-code" name="code" type="text" class="form-input" placeholder="tehran" />
+                </div>
+                <div>
+                  <label for="province-sort-order" class="block text-sm mb-1">ترتیب نمایش</label>
+                  <input id="province-sort-order" name="sortOrder" type="number" min="0" class="form-input" value="0" />
+                </div>
+              </div>
+              <label class="toggle">
+                <input id="province-active" type="checkbox" checked />
+                <span class="toggle-label">فعال</span>
+                <span class="toggle-helper">در فهرست عمومی نمایش داده شود</span>
+              </label>
+              <div class="flex flex-wrap items-center gap-3 pt-2">
+                <button id="province-submit-btn" type="submit" class="btn btn-primary w-auto px-5">
+                  <i class="fa-solid fa-floppy-disk ml-2"></i>
+                  ذخیره استان
+                </button>
+                <button id="province-cancel-btn" type="button" class="btn btn-secondary w-auto px-4 hidden">
+                  <i class="fa-solid fa-rotate-left ml-2"></i>
+                  انصراف
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <div class="xl:col-span-2 space-y-4">
+            <div class="glass rounded-2xl p-6 space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 class="text-xl font-bold">فهرست استان‌ها</h2>
+                  <p class="text-xs text-white/60 mt-1">این لیست تنها استان‌های ذخیره‌شده در پایگاه داده را نمایش می‌دهد.</p>
+                </div>
+                <div class="flex items-center gap-2 text-xs text-white/70">
+                  <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-200" data-province-count="active">۰ استان فعال</span>
+                  <span class="px-3 py-1 rounded-full bg-white/10 text-white/70" data-province-count="total">۰ استان ثبت‌شده</span>
+                </div>
+              </div>
+
+              <div id="provinces-loading-state" class="glass-dark rounded-2xl border border-dashed border-white/10 p-5 text-sm text-white/80 hidden">
+                <div class="flex items-center gap-3">
+                  <span class="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+                  <span>در حال دریافت استان‌ها...</span>
+                </div>
+              </div>
+
+              <div id="provinces-empty-state" class="glass-dark rounded-2xl border border-dashed border-white/10 p-6 text-center text-sm text-white/70 hidden">
+                <p class="font-semibold mb-2">استانی ثبت نشده است</p>
+                <p class="text-xs text-white/60">با استفاده از فرم سمت راست، اولین استان را اضافه کنید.</p>
+              </div>
+
+              <div class="table-container">
+                <table class="table text-sm text-white/80" id="provinces-table">
+                  <thead>
+                    <tr class="text-white/60 text-xs uppercase tracking-wider">
+                      <th class="text-right">نام استان</th>
+                      <th class="text-right">کد</th>
+                      <th class="text-right">ترتیب</th>
+                      <th class="text-right">وضعیت</th>
+                      <th class="text-right">به‌روزرسانی</th>
+                      <th class="text-right">عملیات</th>
+                    </tr>
+                  </thead>
+                  <tbody id="provinces-table-body"></tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "morgan": "^1.10.1",
+        "node-fetch": "^2.6.7",
         "validator": "^13.11.0",
         "winston": "^3.13.0",
         "xss-clean": "^0.1.4"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node src/index.js",
-    "seed:admin": "node src/seed/createAdmin.js"
+    "seed:admin": "node src/seed/createAdmin.js",
+    "seed:provinces": "node src/seed/seedProvinces.js",
+    "test": "node --test"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/__tests__/provinces.routes.test.js
+++ b/server/src/__tests__/provinces.routes.test.js
@@ -1,0 +1,273 @@
+const { describe, before, after, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { once } = require('node:events');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret-key';
+process.env.ENABLE_TRIVIA_POLLER = 'false';
+
+function createInMemoryProvinceModel() {
+  const { randomUUID } = require('node:crypto');
+
+  const store = [];
+
+  const clone = (doc) => ({
+    _id: doc._id,
+    name: doc.name,
+    code: doc.code,
+    sortOrder: doc.sortOrder,
+    isActive: doc.isActive,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt
+  });
+
+  const matchesQuery = (doc, query = {}) => {
+    return Object.entries(query).every(([key, value]) => {
+      if (value && typeof value === 'object' && value.$regex) {
+        const regex = new RegExp(value.$regex, value.$options || '');
+        return regex.test(doc[key] || '');
+      }
+      return doc[key] === value;
+    });
+  };
+
+  const sortResults = (items, sortSpec = {}) => {
+    const entries = Object.entries(sortSpec);
+    if (entries.length === 0) return items;
+    return [...items].sort((a, b) => {
+      for (const [field, direction] of entries) {
+        const dir = direction >= 0 ? 1 : -1;
+        const aValue = a[field] ?? 0;
+        const bValue = b[field] ?? 0;
+        if (aValue < bValue) return -1 * dir;
+        if (aValue > bValue) return 1 * dir;
+      }
+      return 0;
+    });
+  };
+
+  class ProvinceDocument {
+    constructor(snapshot) {
+      Object.defineProperty(this, '_snapshot', { value: snapshot, enumerable: false, writable: true });
+      Object.assign(this, snapshot);
+    }
+
+    toObject() {
+      return clone(this);
+    }
+
+    async save() {
+      const index = store.findIndex((item) => item._id === this._id);
+      if (index === -1) {
+        throw new Error('Document not found');
+      }
+
+      const trimmedName = typeof this.name === 'string' ? this.name.trim() : '';
+      if (!trimmedName) {
+        const error = new Error('Validation error');
+        error.code = 422;
+        throw error;
+      }
+
+      const normalizedCode = typeof this.code === 'string' && this.code.trim() ? this.code.trim().toLowerCase() : null;
+
+      const duplicateName = store.some((item) => item._id !== this._id && item.name === trimmedName);
+      if (duplicateName) {
+        const error = new Error('Duplicate name');
+        error.code = 11000;
+        throw error;
+      }
+
+      if (normalizedCode) {
+        const duplicateCode = store.some((item) => item._id !== this._id && item.code === normalizedCode);
+        if (duplicateCode) {
+          const error = new Error('Duplicate code');
+          error.code = 11000;
+          throw error;
+        }
+      }
+
+      this.name = trimmedName;
+      this.code = normalizedCode;
+      this.sortOrder = Number.isFinite(this.sortOrder) ? Math.max(0, Math.round(this.sortOrder)) : 0;
+      this.isActive = this.isActive !== false;
+      this.updatedAt = new Date();
+
+      store[index] = clone(this);
+      this._snapshot = clone(this);
+      return this;
+    }
+  }
+
+  const buildQuery = (results) => ({
+    sort(sortSpec) {
+      const sorted = sortResults(results, sortSpec);
+      return buildQuery(sorted);
+    },
+    lean() {
+      return Promise.resolve(results.map((item) => ({ ...item })));
+    }
+  });
+
+  return {
+    async create(payload) {
+      const name = typeof payload?.name === 'string' ? payload.name.trim() : '';
+      if (!name) {
+        const error = new Error('Validation error');
+        error.code = 422;
+        throw error;
+      }
+
+      const code = typeof payload?.code === 'string' && payload.code.trim() ? payload.code.trim().toLowerCase() : null;
+      if (store.some((item) => item.name === name || (code && item.code === code))) {
+        const error = new Error('Duplicate');
+        error.code = 11000;
+        throw error;
+      }
+
+      const now = new Date();
+      const doc = {
+        _id: randomUUID(),
+        name,
+        code,
+        sortOrder: Number.isFinite(payload?.sortOrder) ? Math.max(0, Math.round(payload.sortOrder)) : 0,
+        isActive: payload?.isActive !== false,
+        createdAt: now,
+        updatedAt: now
+      };
+
+      store.push(clone(doc));
+      return new ProvinceDocument(doc);
+    },
+
+    find(query = {}) {
+      const results = store.filter((item) => matchesQuery(item, query));
+      return buildQuery(results.map((item) => ({ ...item })));
+    },
+
+    async findById(id) {
+      const found = store.find((item) => item._id === id);
+      if (!found) return null;
+      return new ProvinceDocument({ ...found });
+    },
+
+    async findByIdAndDelete(id) {
+      const index = store.findIndex((item) => item._id === id);
+      if (index === -1) return null;
+      const [removed] = store.splice(index, 1);
+      return new ProvinceDocument({ ...removed });
+    }
+  };
+}
+
+const overrideModule = (path, exportsValue) => {
+  require.cache[path] = { exports: exportsValue };
+};
+
+overrideModule(require.resolve('../models/Province'), createInMemoryProvinceModel());
+overrideModule(require.resolve('../middleware/auth'), {
+  protect: (req, _res, next) => {
+    req.user = { id: 'test-admin', role: 'admin' };
+    next();
+  },
+  adminOnly: (_req, _res, next) => next()
+});
+
+let app;
+let server;
+let baseUrl;
+let createdProvinceId;
+
+describe('Provinces API', () => {
+  before(async () => {
+    const { createApp } = require('../app');
+    app = createApp();
+    server = app.listen(0);
+    await once(server, 'listening');
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  const authorizedFetch = (path, options = {}) => {
+    const headers = { ...(options.headers || {}), Authorization: 'Bearer test-token' };
+    if (options.body && !headers['Content-Type'] && !headers['content-type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+    return fetch(`${baseUrl}${path}`, { ...options, headers });
+  };
+
+  it('creates a province', async () => {
+    const res = await authorizedFetch('/api/provinces', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'تهران', code: 'tehran', sortOrder: 1, isActive: true })
+    });
+
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.name, 'تهران');
+    assert.equal(body.data.code, 'tehran');
+    createdProvinceId = body.data.id;
+    assert.ok(createdProvinceId);
+  });
+
+  it('lists provinces', async () => {
+    const res = await authorizedFetch('/api/provinces');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(Array.isArray(body.data));
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].name, 'تهران');
+  });
+
+  it('updates a province', async () => {
+    const res = await authorizedFetch(`/api/provinces/${createdProvinceId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'البرز', code: 'alborz', isActive: true, sortOrder: 2 })
+    });
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.name, 'البرز');
+    assert.equal(body.data.code, 'alborz');
+    assert.equal(body.data.isActive, true);
+  });
+
+  it('exposes provinces via public route with database values', async () => {
+    const res = await fetch(`${baseUrl}/api/public/provinces`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body));
+    assert.ok(body.length > 0);
+    assert.equal(body[0].name, 'البرز');
+  });
+
+  it('deletes a province and falls back to defaults', async () => {
+    const deleteRes = await authorizedFetch(`/api/provinces/${createdProvinceId}`, { method: 'DELETE' });
+    assert.equal(deleteRes.status, 200);
+    const deleteBody = await deleteRes.json();
+    assert.equal(deleteBody.ok, true);
+
+    const listRes = await authorizedFetch('/api/provinces');
+    assert.equal(listRes.status, 200);
+    const listBody = await listRes.json();
+    assert.equal(listBody.ok, true);
+    assert.equal(listBody.data.length, 0);
+
+    const publicRes = await fetch(`${baseUrl}/api/public/provinces`);
+    assert.equal(publicRes.status, 200);
+    const publicBody = await publicRes.json();
+    assert.ok(Array.isArray(publicBody));
+    assert.ok(publicBody.length > 0);
+    const hasFallbackTehran = publicBody.some((item) => item && item.name === 'تهران');
+    assert.equal(hasFallbackTehran, true);
+  });
+});

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,87 @@
+const path = require('path');
+const express = require('express');
+const helmet = require('helmet');
+const cors = require('cors');
+const rateLimit = require('express-rate-limit');
+const mongoSanitize = require('express-mongo-sanitize');
+const xss = require('xss-clean');
+const hpp = require('hpp');
+const morgan = require('morgan');
+
+const env = require('./config/env');
+const errorHandler = require('./middleware/error');
+const triviaRoutes = require('./routes/trivia');
+
+function createApp() {
+  const app = express();
+
+  app.use(helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'", 'https://cdn.tailwindcss.com'],
+        scriptSrcElem: ["'self'", "'unsafe-inline'", 'https://cdn.tailwindcss.com'],
+        scriptSrcAttr: ["'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com', 'https://cdnjs.cloudflare.com'],
+        fontSrc: ["'self'", 'https://fonts.gstatic.com', 'https://cdnjs.cloudflare.com', 'data:'],
+        imgSrc: ["'self'", 'data:', 'https://i.pravatar.cc'],
+        connectSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        upgradeInsecureRequests: []
+      }
+    }
+  }));
+
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '100kb' }));
+  app.use(mongoSanitize());
+  app.use(xss());
+  app.use(hpp());
+
+  if (env.nodeEnv !== 'production') {
+    app.use(morgan('dev'));
+  }
+
+  const allowedOrigins = env.cors.allowedOrigins;
+  app.use(cors({
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true);
+      if (allowedOrigins.length === 0 || allowedOrigins.includes(origin)) return cb(null, true);
+      return cb(new Error('Not allowed by CORS'));
+    }
+  }));
+
+  app.use('/api', rateLimit({ windowMs: 15 * 60 * 1000, max: 1000 }));
+
+  app.use(express.static(path.join(__dirname, '..', '..')));
+
+  app.get('/admin', (req, res) => {
+    res.sendFile(path.join(__dirname, '..', '..', 'Admin-Panel.html'));
+  });
+
+  app.get('/bot', (req, res) => {
+    res.sendFile(path.join(__dirname, '..', '..', 'IQuiz-bot.html'));
+  });
+
+  app.get('/favicon.ico', (req, res) => res.status(204).end());
+
+  app.get('/healthz', (req, res) => res.json({ ok: true, status: 'healthy' }));
+
+  app.use('/api/auth', require('./routes/auth.routes'));
+  app.use('/api/categories', require('./routes/categories.routes'));
+  app.use('/api/questions', require('./routes/questions.routes'));
+  app.use('/api/users', require('./routes/users.routes'));
+  app.use('/api/achievements', require('./routes/achievements.routes'));
+  app.use('/api/ads', require('./routes/ads.routes'));
+  app.use('/api/provinces', require('./routes/provinces.routes'));
+  app.use('/api/public', require('./routes/public.routes'));
+  app.use('/api/trivia', triviaRoutes);
+  app.use('/api', require('./routes/trivia-triviaapi'));
+
+  app.use(errorHandler);
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/server/src/controllers/provinces.controller.js
+++ b/server/src/controllers/provinces.controller.js
@@ -1,0 +1,130 @@
+const Province = require('../models/Province');
+
+const truthy = new Set(['true', '1', 'yes', 'on']);
+const falsy = new Set(['false', '0', 'no', 'off']);
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+const sanitizeCode = (value) => {
+  const code = sanitizeString(value).toLowerCase();
+  return code || null;
+};
+const sanitizeSortOrder = (value, fallback = 0) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  const rounded = Math.round(num);
+  return Math.min(Math.max(rounded, 0), 1000);
+};
+const parseBoolean = (value, defaultValue = false) => {
+  if (value === undefined || value === null) return defaultValue;
+  const normalized = String(value).trim().toLowerCase();
+  if (truthy.has(normalized)) return true;
+  if (falsy.has(normalized)) return false;
+  return defaultValue;
+};
+
+function mapProvinceDocument(doc) {
+  if (!doc) return null;
+  const raw = doc.toObject ? doc.toObject() : doc;
+  const id = raw._id ? String(raw._id) : raw.id ? String(raw.id) : '';
+  return {
+    id,
+    name: raw.name || '',
+    code: raw.code || '',
+    sortOrder: Number.isFinite(raw.sortOrder) ? Number(raw.sortOrder) : 0,
+    isActive: raw.isActive !== false,
+    createdAt: raw.createdAt || null,
+    updatedAt: raw.updatedAt || null
+  };
+}
+
+exports.list = async (req, res, next) => {
+  try {
+    const query = {};
+    if (Object.prototype.hasOwnProperty.call(req.query, 'active')) {
+      const active = parseBoolean(req.query.active, null);
+      if (active === true) query.isActive = true;
+      else if (active === false) query.isActive = false;
+    }
+    if (req.query.q) {
+      const q = sanitizeString(req.query.q);
+      if (q) {
+        query.name = { $regex: q, $options: 'i' };
+      }
+    }
+    const provinces = await Province.find(query).sort({ sortOrder: 1, name: 1 }).lean();
+    res.json({ ok: true, data: provinces.map(mapProvinceDocument) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.create = async (req, res, next) => {
+  try {
+    const name = sanitizeString(req.body.name);
+    if (!name) {
+      return res.status(400).json({ ok: false, message: 'نام استان الزامی است' });
+    }
+    const code = sanitizeCode(req.body.code);
+    const sortOrder = sanitizeSortOrder(req.body.sortOrder, 0);
+    const isActive = parseBoolean(req.body.isActive, true);
+
+    const province = await Province.create({ name, code, sortOrder, isActive });
+    res.status(201).json({ ok: true, data: mapProvinceDocument(province) });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ ok: false, message: 'استانی با این نام یا کد از قبل وجود دارد' });
+    }
+    next(error);
+  }
+};
+
+exports.update = async (req, res, next) => {
+  try {
+    const province = await Province.findById(req.params.id);
+    if (!province) {
+      return res.status(404).json({ ok: false, message: 'استان یافت نشد' });
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'name')) {
+      const name = sanitizeString(req.body.name);
+      if (!name) {
+        return res.status(400).json({ ok: false, message: 'نام استان نمی‌تواند خالی باشد' });
+      }
+      province.name = name;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'code')) {
+      province.code = sanitizeCode(req.body.code);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'sortOrder')) {
+      province.sortOrder = sanitizeSortOrder(req.body.sortOrder, province.sortOrder);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'isActive')) {
+      province.isActive = parseBoolean(req.body.isActive, province.isActive);
+    }
+
+    await province.save();
+    res.json({ ok: true, data: mapProvinceDocument(province) });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ ok: false, message: 'استانی با این نام یا کد از قبل وجود دارد' });
+    }
+    next(error);
+  }
+};
+
+exports.remove = async (req, res, next) => {
+  try {
+    const result = await Province.findByIdAndDelete(req.params.id);
+    if (!result) {
+      return res.status(404).json({ ok: false, message: 'استان یافت نشد' });
+    }
+    res.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.mapProvinceDocument = mapProvinceDocument;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,104 +1,14 @@
 // server/src/index.js
 require('dotenv').config();
-const path = require('path');
-const express = require('express');
-const helmet = require('helmet');
-const cors = require('cors');
-const rateLimit = require('express-rate-limit');
-const mongoSanitize = require('express-mongo-sanitize');
-const xss = require('xss-clean');
-const hpp = require('hpp');
-const morgan = require('morgan');
-
 const env = require('./config/env');
 const connectDB = require('./config/db');
 const logger = require('./config/logger');
-const errorHandler = require('./middleware/error');
-const triviaRoutes = require('./routes/trivia');
 const { startTriviaPoller } = require('./poller/triviaPoller');
 const { ensureInitialCategories, syncProviderCategories } = require('./services/categorySeeder');
+const { createApp } = require('./app');
 
 // init
-const app = express();
-
-// ───────────────── Security & parsers
-// CSP کامل برای Tailwind CDN، Google Fonts، cdnjs و آواتار نمونه
-// یادآوری: برای اینکه HTML استاتیک (که اسکریپت‌های درون‌خطی دارد) درست کار کند، باید
-// علاوه بر script-src، دستورهای script-src-elem و script-src-attr را هم بازتعریف کنیم؛
-// در غیر اینصورت Helmet برای آن‌ها مقدار «'none'» قرار می‌دهد و اجرای اسکریپت‌ها متوقف می‌شود.
-app.use(helmet({
-  contentSecurityPolicy: {
-    useDefaults: true,
-    directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.tailwindcss.com"],
-      scriptSrcElem: ["'self'", "'unsafe-inline'", "https://cdn.tailwindcss.com"],
-      scriptSrcAttr: ["'unsafe-inline'"],
-      styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://cdnjs.cloudflare.com"],
-      fontSrc: ["'self'", "https://fonts.gstatic.com", "https://cdnjs.cloudflare.com", "data:"],
-      imgSrc: ["'self'", "data:", "https://i.pravatar.cc"],
-      connectSrc: ["'self'"],
-      objectSrc: ["'none'"],
-      upgradeInsecureRequests: []
-    }
-  }
-}));
-
-app.use(express.json({ limit: '100kb' }));
-app.use(express.urlencoded({ extended: true, limit: '100kb' }));
-app.use(mongoSanitize());
-app.use(xss());
-app.use(hpp());
-
-// logging
-if (env.nodeEnv !== 'production') app.use(morgan('dev'));
-
-// cors
-const allowedOrigins = env.cors.allowedOrigins;
-
-app.use(cors({
-  origin: (origin, cb) => {
-    if (!origin) return cb(null, true);
-    if (allowedOrigins.length === 0 || allowedOrigins.includes(origin)) return cb(null, true);
-    cb(new Error('Not allowed by CORS'));
-  }
-}));
-
-// rate limit
-app.use('/api', rateLimit({ windowMs: 15 * 60 * 1000, max: 1000 }));
-
-// ───────────────── Static files
-// توجه: HTMLهای شما (Admin-Panel.html / IQuiz-bot.html) در ریشه‌ی پروژه هستند (یک سطح بالاتر از `server`).
-app.use(express.static(path.join(__dirname, '..', '..'))); // سرو از ریشه پروژه
-
-// روت دوستانه برای پنل ادمین
-app.get('/admin', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', '..', 'Admin-Panel.html'));
-});
-
-// روت تست برای فایل بات (اختیاری)
-app.get('/bot', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', '..', 'IQuiz-bot.html'));
-});
-
-// جلوگیری از 404 برای favicon
-app.get('/favicon.ico', (req, res) => res.status(204).end());
-
-// ───────────────── API routes
-app.get('/healthz', (req, res) => res.json({ ok: true, status: 'healthy' }));
-
-app.use('/api/auth', require('./routes/auth.routes'));
-app.use('/api/categories', require('./routes/categories.routes'));
-app.use('/api/questions', require('./routes/questions.routes'));
-app.use('/api/users', require('./routes/users.routes'));
-app.use('/api/achievements', require('./routes/achievements.routes'));
-app.use('/api/ads', require('./routes/ads.routes'));
-app.use('/api/public', require('./routes/public.routes'));
-app.use('/api/trivia', triviaRoutes);
-app.use('/api', require('./routes/trivia-triviaapi'));
-
-// error handler
-app.use(errorHandler);
+const app = createApp();
 
 // ───────────────── Start
 let server;

--- a/server/src/models/Province.js
+++ b/server/src/models/Province.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose');
+
+const ProvinceSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 120,
+    unique: true
+  },
+  code: {
+    type: String,
+    trim: true,
+    lowercase: true,
+    maxlength: 60,
+    unique: true,
+    sparse: true
+  },
+  sortOrder: {
+    type: Number,
+    default: 0,
+    min: 0,
+    max: 1000
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  }
+}, {
+  timestamps: true
+});
+
+ProvinceSchema.index({ name: 1 });
+ProvinceSchema.index({ code: 1 }, { unique: true, sparse: true });
+
+module.exports = mongoose.model('Province', ProvinceSchema);

--- a/server/src/routes/provinces.routes.js
+++ b/server/src/routes/provinces.routes.js
@@ -1,0 +1,11 @@
+const router = require('express').Router();
+const { protect, adminOnly } = require('../middleware/auth');
+const ctrl = require('../controllers/provinces.controller');
+
+router.use(protect, adminOnly);
+router.get('/', ctrl.list);
+router.post('/', ctrl.create);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/server/src/seed/seedProvinces.js
+++ b/server/src/seed/seedProvinces.js
@@ -1,0 +1,48 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Province = require('../models/Province');
+const { getFallbackProvinces } = require('../services/publicContent');
+
+(async () => {
+  try {
+    const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/iquiz';
+    await mongoose.connect(mongoUri, {});
+
+    const existing = await Province.countDocuments();
+    if (existing > 0) {
+      console.log('✅ Provinces already exist, skipping seeding.');
+      process.exit(0);
+    }
+
+    const fallback = getFallbackProvinces();
+    if (!Array.isArray(fallback) || fallback.length === 0) {
+      console.log('⚠️  No fallback provinces available. Nothing to seed.');
+      process.exit(0);
+    }
+
+    const documents = fallback
+      .map((item, index) => {
+        const name = typeof item?.name === 'string' ? item.name.trim() : '';
+        if (!name) return null;
+        return {
+          name,
+          code: `province-${index + 1}`,
+          sortOrder: index,
+          isActive: true
+        };
+      })
+      .filter(Boolean);
+
+    if (!documents.length) {
+      console.log('⚠️  No valid fallback provinces to seed.');
+      process.exit(0);
+    }
+
+    await Province.insertMany(documents, { ordered: false });
+    console.log(`✅ Seeded ${documents.length} provinces.`);
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Failed to seed provinces:', error.message);
+    process.exit(1);
+  }
+})();

--- a/server/src/services/provinceService.js
+++ b/server/src/services/provinceService.js
@@ -1,0 +1,83 @@
+const Province = require('../models/Province');
+const logger = require('../config/logger');
+const { getFallbackProvinces } = require('./publicContent');
+const { mapProvinceDocument } = require('../controllers/provinces.controller');
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+function normalizeProvince(raw, index = 0) {
+  const base = mapProvinceDocument(raw) || {};
+  const name = sanitizeString(base.name);
+  const code = sanitizeString(base.code).toLowerCase();
+  const sortOrder = Number.isFinite(base.sortOrder) ? Number(base.sortOrder) : index;
+  const score = Number.isFinite(raw?.score) ? Number(raw.score) : 0;
+  const members = Number.isFinite(raw?.members) ? Number(raw.members) : 0;
+  return {
+    ...base,
+    name,
+    code,
+    sortOrder,
+    score,
+    members,
+    isActive: base.isActive !== false
+  };
+}
+
+function mapFallbackProvince(item, index) {
+  const name = sanitizeString(item?.name);
+  if (!name) return null;
+  const code = sanitizeString(item?.code).toLowerCase();
+  const sortOrder = Number.isFinite(item?.sortOrder) ? Number(item.sortOrder) : index;
+  const score = Number.isFinite(item?.score) ? Number(item.score) : 0;
+  const members = Number.isFinite(item?.members) ? Number(item.members) : 0;
+  return {
+    id: null,
+    name,
+    code,
+    sortOrder,
+    score,
+    members,
+    isActive: true,
+    createdAt: null,
+    updatedAt: null
+  };
+}
+
+async function getActiveProvincesFromDb() {
+  try {
+    const docs = await Province.find({ isActive: true }).sort({ sortOrder: 1, name: 1 }).lean();
+    return docs.map((doc, index) => normalizeProvince(doc, index)).filter((item) => item.name);
+  } catch (error) {
+    logger.warn(`Failed to load provinces from database: ${error.message}`);
+    return [];
+  }
+}
+
+function getFallbackProvinceList() {
+  return getFallbackProvinces()
+    .map((item, index) => mapFallbackProvince(item, index))
+    .filter(Boolean);
+}
+
+async function getActiveProvincesWithFallback() {
+  const provinces = await getActiveProvincesFromDb();
+  if (provinces.length > 0) {
+    return provinces;
+  }
+  return getFallbackProvinceList();
+}
+
+async function filterAllowedProvinceNames(names = []) {
+  const list = Array.isArray(names) ? names : [];
+  const sanitized = list.map((item) => sanitizeString(item)).filter(Boolean);
+  if (sanitized.length === 0) return [];
+  const provinces = await getActiveProvincesWithFallback();
+  const allowed = new Set(provinces.map((province) => province.name));
+  return sanitized.filter((name) => allowed.has(name));
+}
+
+module.exports = {
+  getActiveProvincesWithFallback,
+  filterAllowedProvinceNames,
+  normalizeProvince
+};


### PR DESCRIPTION
## Summary
- add a province management section and navigation entry to the admin panel with CRUD table and form wiring to the API
- implement Express app refactor plus province model/controller/routes/service, update ads/public flows to read provinces from Mongo, and add a seed script
- cover the new endpoints with integration-style tests using an in-memory model stub to keep the suite self-contained

## Testing
- npm test --prefix server

------
https://chatgpt.com/codex/tasks/task_e_68ce6e49b1dc8326b80c58654d1048bb