### PR TITLE
Refactor helper utilities into dedicated modules

### DIFF
--- a/Iquiz-assets/src/utils/dom.js
+++ b/Iquiz-assets/src/utils/dom.js
@@ -1,0 +1,32 @@
+export const $ = (selector) => document.querySelector(selector);
+export const $$ = (selector) => Array.from(document.querySelectorAll(selector));
+
+export function ensureButtonType(root = document) {
+  root.querySelectorAll('button:not([type])').forEach((btn) => {
+    btn.type = 'button';
+  });
+}
+
+function handleAddedNode(node) {
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+  if (node.matches && node.matches('button:not([type])')) node.type = 'button';
+  if (node.querySelectorAll) ensureButtonType(node);
+}
+
+export const buttonTypeObserver = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    mutation.addedNodes.forEach(handleAddedNode);
+  });
+});
+
+export function startButtonTypeObserver() {
+  if (!document.body) return;
+  ensureButtonType();
+  buttonTypeObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', startButtonTypeObserver, { once: true });
+} else {
+  startButtonTypeObserver();
+}

--- a/Iquiz-assets/src/utils/feedback.js
+++ b/Iquiz-assets/src/utils/feedback.js
@@ -1,0 +1,122 @@
+import { $ } from './dom.js';
+
+const defaultSettings = { sound: true, haptics: true };
+let getSettings = () => defaultSettings;
+
+const resolveSettings = () => {
+  try {
+    return getSettings() ?? defaultSettings;
+  } catch {
+    return defaultSettings;
+  }
+};
+
+export function configureFeedback(getter) {
+  if (typeof getter === 'function') {
+    getSettings = getter;
+  }
+}
+
+export function vibrate(pattern) {
+  try {
+    const settings = resolveSettings();
+    if (settings.haptics && typeof navigator !== 'undefined' && navigator.vibrate) {
+      navigator.vibrate(pattern);
+    }
+  } catch {}
+}
+
+export function toast(html, ms = 2200) {
+  const el = document.createElement('div');
+  el.className =
+    'fixed top-20 left-1/2 -translate-x-1/2 glass px-5 py-3 rounded-2xl text-white font-bold z-50 fade-in';
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), ms);
+}
+
+export const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let audioCtx;
+const ensureAudioContext = () => {
+  if (audioCtx) return audioCtx;
+  const Ctor = window.AudioContext || window.webkitAudioContext;
+  if (!Ctor) return null;
+  audioCtx = new Ctor();
+  return audioCtx;
+};
+
+const shouldPlaySound = () => {
+  const settings = resolveSettings();
+  return settings.sound !== false;
+};
+
+function beep(frequency = 880, duration = 0.12, type = 'sine') {
+  if (!shouldPlaySound()) return;
+  const ctx = ensureAudioContext();
+  if (!ctx) return;
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+  oscillator.type = type;
+  oscillator.frequency.value = frequency;
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+  const now = ctx.currentTime;
+  gain.gain.setValueAtTime(0.001, now);
+  gain.gain.exponentialRampToValueAtTime(0.2, now + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + duration);
+  oscillator.start();
+  oscillator.stop(now + duration + 0.02);
+}
+
+export const SFX = {
+  correct: () => {
+    beep(880);
+    setTimeout(() => beep(1320, 0.1, 'triangle'), 90);
+  },
+  wrong: () => beep(160, 0.25, 'sawtooth'),
+  tick: () => beep(660, 0.05),
+  coin: () => {
+    beep(1200, 0.08);
+    setTimeout(() => beep(1600, 0.08), 70);
+  },
+};
+
+export function shootConfetti() {
+  const canvas = $('#confetti');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const W = (canvas.width = window.innerWidth);
+  const H = (canvas.height = window.innerHeight);
+  const pieces = Array.from({ length: 120 }, () => ({
+    x: Math.random() * W,
+    y: -20 - Math.random() * H,
+    r: 4 + Math.random() * 6,
+    c: ['#fde047', '#fb923c', '#a78bfa', '#ec4899', '#34d399'][Math.floor(Math.random() * 5)],
+    v: 1 + Math.random() * 3,
+    a: Math.random() * Math.PI * 2,
+  }));
+  let t = 0;
+  let run = true;
+  (function anim() {
+    if (!run) return;
+    ctx.clearRect(0, 0, W, H);
+    for (const piece of pieces) {
+      ctx.fillStyle = piece.c;
+      ctx.beginPath();
+      ctx.arc(piece.x, piece.y, piece.r, 0, Math.PI * 2);
+      ctx.fill();
+      piece.y += piece.v;
+      piece.x += Math.sin(piece.a + t / 15);
+      if (piece.y > H + 10) piece.y = -10;
+    }
+    t += 1;
+    const id = requestAnimationFrame(anim);
+    setTimeout(() => {
+      run = false;
+      cancelAnimationFrame(id);
+      ctx.clearRect(0, 0, W, H);
+    }, 2200);
+  })();
+}

--- a/Iquiz-assets/src/utils/format.js
+++ b/Iquiz-assets/src/utils/format.js
@@ -1,0 +1,57 @@
+export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const faNum = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+  return Number(value).toLocaleString('fa-IR');
+};
+
+export const faDecimal = (value, digits = 1) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '—';
+  return numeric.toLocaleString('fa-IR', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+};
+
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return 'کمتر از یک دقیقه';
+  const totalMinutes = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [];
+  if (hours > 0) parts.push(`${faNum(hours)} ساعت`);
+  if (minutes > 0) parts.push(`${faNum(minutes)} دقیقه`);
+  return parts.length ? parts.join(' و ') : 'کمتر از یک دقیقه';
+}
+
+export function formatRelativeTime(timestamp) {
+  if (!Number.isFinite(timestamp)) return 'همین حالا';
+  try {
+    const diff = timestamp - Date.now();
+    const abs = Math.abs(diff);
+    const rtf =
+      formatRelativeTime.rtf ||
+      (formatRelativeTime.rtf = new Intl.RelativeTimeFormat('fa', { numeric: 'auto' }));
+    const units = [
+      { limit: 60 * 1000, divisor: 1000, unit: 'second' },
+      { limit: 60 * 60 * 1000, divisor: 60 * 1000, unit: 'minute' },
+      { limit: 24 * 60 * 60 * 1000, divisor: 60 * 60 * 1000, unit: 'hour' },
+      { limit: 7 * 24 * 60 * 60 * 1000, divisor: 24 * 60 * 60 * 1000, unit: 'day' },
+      { limit: 30 * 24 * 60 * 60 * 1000, divisor: 7 * 24 * 60 * 60 * 1000, unit: 'week' },
+      { limit: 365 * 24 * 60 * 60 * 1000, divisor: 30 * 24 * 60 * 60 * 1000, unit: 'month' },
+      { limit: Infinity, divisor: 365 * 24 * 60 * 60 * 1000, unit: 'year' },
+    ];
+    for (const { limit, divisor, unit } of units) {
+      if (abs < limit) {
+        const value = Math.round(diff / divisor);
+        return rtf.format(value, unit);
+      }
+    }
+  } catch {}
+  try {
+    return new Date(timestamp).toLocaleString('fa-IR');
+  } catch {
+    return 'همین حالا';
+  }
+}


### PR DESCRIPTION
## Summary
- extract DOM helper utilities into `src/utils/dom.js` and import them in the main bundle
- move numeric/time formatting helpers into `src/utils/format.js`
- relocate feedback helpers (vibrate, toast, wait, SFX, confetti) into `src/utils/feedback.js` with configurable settings wiring

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb6f2c4508326932040481e094114