### PR TITLE
Refactor quiz engine into dedicated modules

### DIFF
--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -1,0 +1,285 @@
+import { $, $$ } from '../../utils/dom.js';
+import { faNum } from '../../utils/format.js';
+import { toast, SFX } from '../../utils/feedback.js';
+import { State } from '../../state/state.js';
+import { saveState } from '../../state/persistence.js';
+
+const LIFELINE_COST = 3;
+
+const defaultDeps = {
+  renderTopBars: () => {},
+  resetTimer: () => {},
+  selectAnswer: () => {},
+  nextQuestion: () => {},
+  addExtraTime: () => {},
+  logEvent: () => {},
+};
+
+let deps = { ...defaultDeps };
+
+export function configureQuizEngine(config = {}) {
+  deps = { ...deps, ...config };
+}
+
+function callDependency(key, ...args) {
+  const fn = deps?.[key];
+  if (typeof fn === 'function') {
+    return fn(...args);
+  }
+  return undefined;
+}
+
+function animateKeyChip() {
+  const chip = $('#lives')?.closest('.chip');
+  if (!chip) return;
+  chip.classList.remove('attention');
+  void chip.offsetWidth;
+  chip.classList.add('attention');
+  setTimeout(() => chip.classList.remove('attention'), 650);
+}
+
+export function updateLifelineStates() {
+  const hasKeys = State.lives >= LIFELINE_COST;
+  ['life-5050', 'life-skip', 'life-pause'].forEach((id) => {
+    const btn = $('#' + id);
+    if (!btn) return;
+    if (btn.disabled) {
+      btn.dataset.insufficient = 'false';
+      const costEl = btn.querySelector('.lifeline-cost');
+      if (costEl) costEl.classList.remove('not-enough');
+      return;
+    }
+    btn.dataset.insufficient = hasKeys ? 'false' : 'true';
+    const costEl = btn.querySelector('.lifeline-cost');
+    if (costEl) costEl.classList.toggle('not-enough', !hasKeys);
+  });
+}
+
+export function spendLifelineCost() {
+  if (State.lives < LIFELINE_COST) {
+    toast(`برای استفاده از این قابلیت به ${faNum(LIFELINE_COST)} کلید نیاز داری`);
+    animateKeyChip();
+    return false;
+  }
+  State.lives -= LIFELINE_COST;
+  callDependency('renderTopBars');
+  saveState();
+  animateKeyChip();
+  return true;
+}
+
+export function markLifelineUsed(id) {
+  const btn = typeof id === 'string' ? $('#' + id) : id;
+  if (!btn) return;
+  btn.disabled = true;
+  btn.dataset.used = 'true';
+  btn.dataset.insufficient = 'false';
+  const costEl = btn.querySelector('.lifeline-cost');
+  if (costEl) {
+    costEl.classList.remove('not-enough');
+    costEl.classList.add('hidden');
+  }
+  const statusEl = btn.querySelector('.lifeline-status');
+  if (statusEl) statusEl.classList.remove('hidden');
+  updateLifelineStates();
+}
+
+export function resetLifelinesUI() {
+  ['life-5050', 'life-skip', 'life-pause'].forEach((id) => {
+    const btn = $('#' + id);
+    if (!btn) return;
+    btn.disabled = false;
+    btn.dataset.used = 'false';
+    btn.dataset.insufficient = 'false';
+    const costEl = btn.querySelector('.lifeline-cost');
+    if (costEl) {
+      costEl.classList.remove('hidden', 'not-enough');
+    }
+    const statusEl = btn.querySelector('.lifeline-status');
+    if (statusEl) {
+      statusEl.classList.add('hidden');
+    }
+  });
+  updateLifelineStates();
+}
+
+let used5050 = false;
+let usedSkip = false;
+let usedTimeBoost = false;
+
+function resetLifelineUsage() {
+  used5050 = false;
+  usedSkip = false;
+  usedTimeBoost = false;
+}
+
+export function life5050() {
+  if (used5050) {
+    toast('۵۰–۵۰ را قبلاً استفاده کردی 😅');
+    return;
+  }
+  if (!spendLifelineCost()) return;
+  used5050 = true;
+  markLifelineUsed('life-5050');
+  const correct = State.quiz.list[State.quiz.idx].a;
+  const idxs = [0, 1, 2, 3]
+    .filter((i) => i !== correct)
+    .sort(() => Math.random() - 0.5)
+    .slice(0, 2);
+  idxs.forEach((i) => {
+    const el = $$('#choices .choice')[i];
+    if (el) {
+      el.style.opacity = 0.35;
+      el.style.pointerEvents = 'none';
+    }
+  });
+  toast('<i class="fas fa-percent ml-1"></i> دو گزینه حذف شد');
+  SFX.coin();
+}
+
+export function lifeSkip() {
+  if (usedSkip) {
+    toast('پرش فقط یک‌بار مجازه');
+    return;
+  }
+  if (!spendLifelineCost()) return;
+  usedSkip = true;
+  markLifelineUsed('life-skip');
+  clearInterval(State.quiz.timer);
+  const cur = State.quiz.list[State.quiz.idx];
+  State.quiz.results.push({ q: cur.q, ok: false, correct: cur.c[cur.a], you: '— (پرش)' });
+  saveState();
+  toast('<i class="fas fa-forward ml-1"></i> به سؤال بعدی رفتی');
+  callDependency('nextQuestion');
+  SFX.coin();
+}
+
+export function lifePause() {
+  if (usedTimeBoost) {
+    toast('فقط یک‌بار می‌توانی زمان اضافه کنی');
+    return;
+  }
+  if (!spendLifelineCost()) return;
+  usedTimeBoost = true;
+  markLifelineUsed('life-pause');
+  callDependency('addExtraTime', 10);
+  saveState();
+  toast(`<i class="fas fa-stopwatch ml-1"></i> ${faNum(10)} ثانیه به زمانت اضافه شد`);
+  SFX.coin();
+}
+
+export function renderQuestionUI(q) {
+  const catLabel = State.quiz.cat || q.cat || '—';
+  const diffLabel = State.quiz.diff || q.diff || '—';
+  $('#quiz-cat').innerHTML = `<i class="fas fa-folder ml-1"></i> ${catLabel}`;
+  $('#quiz-diff').innerHTML = `<i class="fas fa-signal ml-1"></i> ${diffLabel}`;
+  $('#qnum').textContent = faNum(State.quiz.idx + 1);
+  $('#qtotal').textContent = faNum(State.quiz.list.length);
+  $('#question').textContent = q.q;
+  const authorWrapper = $('#question-author');
+  const authorNameEl = $('#question-author-name');
+  if (authorWrapper && authorNameEl) {
+    const sourceKey = (q.source || '').toString().toLowerCase();
+    let authorDisplay = (q.authorName || '').toString().trim();
+    if (!authorDisplay) {
+      authorDisplay = sourceKey === 'community' ? 'قهرمان ناشناس' : 'تیم محتوایی IQuiz';
+    }
+    authorNameEl.textContent = authorDisplay;
+    const authorLabelEl = authorWrapper.querySelector('[data-author-text]');
+    if (authorLabelEl) {
+      authorLabelEl.textContent = sourceKey === 'community'
+        ? 'پیشنهاد جامعه آیکوئیز'
+        : 'منتشر شده توسط تیم محتوا';
+    }
+    const authorIconEl = authorWrapper.querySelector('[data-author-icon]');
+    if (authorIconEl) {
+      authorIconEl.className = sourceKey === 'community'
+        ? 'fas fa-user-astronaut text-lg'
+        : 'fas fa-shield-heart text-lg';
+    }
+    const badgeEl = authorWrapper.querySelector('[data-author-badge]');
+    if (badgeEl) {
+      if (sourceKey === 'community') {
+        badgeEl.style.background = 'linear-gradient(135deg, rgba(251,191,36,0.9), rgba(249,115,22,0.8))';
+        badgeEl.style.color = '#0f172a';
+      } else {
+        badgeEl.style.background = 'linear-gradient(135deg, rgba(94,234,212,0.85), rgba(59,130,246,0.78))';
+        badgeEl.style.color = '#0f172a';
+      }
+    }
+    authorWrapper.classList.remove('hidden');
+  }
+  const box = $('#choices');
+  if (box) box.innerHTML = '';
+  q.c.forEach((txt, idx) => {
+    const btn = document.createElement('button');
+    btn.className = 'choice';
+    btn.setAttribute('aria-label', 'گزینه ' + faNum(idx + 1));
+    btn.innerHTML = `<span class="chip">${faNum(idx + 1)}</span><span>${txt}</span>`;
+    btn.addEventListener('click', () => callDependency('selectAnswer', idx));
+    box?.appendChild(btn);
+  });
+}
+
+export function beginQuizSession({ cat, diff, diffValue, questions, count, source }) {
+  if (!Array.isArray(questions) || questions.length === 0) return false;
+
+  resetLifelineUsage();
+  resetLifelinesUI();
+
+  State.quiz.cat = cat || State.quiz.cat || '—';
+  if (diff != null) {
+    State.quiz.diff = diff || 'آسان';
+  } else if (!State.quiz.diff) {
+    State.quiz.diff = 'آسان';
+  }
+  if (diffValue != null) {
+    State.quiz.diffValue = diffValue;
+  } else if (State.quiz.diffValue == null && typeof State.quiz.diff === 'string') {
+    const diffLabelLower = State.quiz.diff.toLowerCase();
+    if (State.quiz.diff.indexOf('سخت') >= 0 || diffLabelLower === 'hard') {
+      State.quiz.diffValue = 'hard';
+    } else if (State.quiz.diff.indexOf('متوسط') >= 0 || diffLabelLower === 'medium' || diffLabelLower === 'normal') {
+      State.quiz.diffValue = 'medium';
+    } else {
+      State.quiz.diffValue = 'easy';
+    }
+  }
+  State.quiz.list = questions.map((q) => ({
+    ...q,
+    cat: State.quiz.cat,
+    diff: State.quiz.diff,
+    diffValue: State.quiz.diffValue,
+  }));
+  State.quiz.idx = 0;
+  State.quiz.sessionEarned = 0;
+  State.quiz.results = [];
+  State.quiz.inProgress = true;
+  State.quiz.answered = false;
+
+  callDependency('renderTopBars');
+  renderQuestionUI(State.quiz.list[0]);
+
+  const diffLabel = State.quiz.diff;
+  const duration = diffLabel === 'سخت' ? 20 : diffLabel === 'متوسط' ? 25 : 30;
+  callDependency('resetTimer', duration);
+
+  if (State.duelOpponent) {
+    $('#duel-opponent-name').textContent = State.duelOpponent.name;
+    $('#duel-banner').classList.remove('hidden');
+  } else {
+    $('#duel-banner').classList.add('hidden');
+  }
+
+  callDependency('logEvent', 'quiz_start', {
+    category: State.quiz.cat,
+    difficulty: State.quiz.diff,
+    difficulty_value: State.quiz.diffValue,
+    questionCount: count || State.quiz.list.length,
+    source,
+  });
+
+  return true;
+}
+
+export { LIFELINE_COST };

--- a/Iquiz-assets/src/features/quiz/loader.js
+++ b/Iquiz-assets/src/features/quiz/loader.js
@@ -1,0 +1,214 @@
+import Api from '../../services/api.js';
+import { toast } from '../../utils/feedback.js';
+import { State } from '../../state/state.js';
+import {
+  getActiveCategories,
+  getFirstCategory,
+  findCategoryById,
+  getCategoryDifficultyPool,
+  getEffectiveDiffs,
+} from '../../state/admin.js';
+import { beginQuizSession } from './engine.js';
+
+function pickDifficulty(diffPool, { requested, stateValue, stateLabel }) {
+  let selected = null;
+
+  const tryMatch = (predicate) => {
+    if (selected) return;
+    for (let idx = 0; idx < diffPool.length; idx += 1) {
+      const diffOpt = diffPool[idx];
+      if (diffOpt && predicate(diffOpt)) {
+        selected = diffOpt;
+        break;
+      }
+    }
+  };
+
+  if (requested != null) {
+    tryMatch((diffOpt) => diffOpt.value === requested || diffOpt.label === requested);
+  }
+  if (!selected && stateValue != null) {
+    tryMatch((diffOpt) => diffOpt.value === stateValue);
+  }
+  if (!selected && stateLabel != null) {
+    tryMatch((diffOpt) => diffOpt.label === stateLabel);
+  }
+  if (!selected) {
+    tryMatch((diffOpt) => {
+      const valLower = String(diffOpt.value || '').toLowerCase();
+      const labelLower = String(diffOpt.label || '').toLowerCase();
+      return (
+        valLower === 'medium' ||
+        valLower === 'normal' ||
+        labelLower.includes('متوسط') ||
+        labelLower.includes('medium') ||
+        labelLower.includes('normal')
+      );
+    });
+  }
+  if (!selected && diffPool.length) selected = diffPool[0];
+  return selected;
+}
+
+export function normalizeQuestions(list) {
+  const normalized = [];
+  if (!Array.isArray(list)) return normalized;
+
+  for (let i = 0; i < list.length; i += 1) {
+    const q = list[i] || {};
+    const rawChoices = q.options || q.choices || [];
+    const choices = [];
+
+    if (Array.isArray(rawChoices)) {
+      for (let j = 0; j < rawChoices.length; j += 1) {
+        const opt = rawChoices[j];
+        let txt;
+        if (typeof opt === 'string') {
+          txt = opt;
+        } else {
+          txt = (opt && (opt.text || opt.title || opt.value)) || '';
+        }
+        txt = (txt == null ? '' : String(txt)).trim();
+        choices.push(txt);
+      }
+    }
+
+    let answerIdx;
+    if (typeof q.answerIndex === 'number') {
+      answerIdx = q.answerIndex;
+    } else if (Array.isArray(rawChoices)) {
+      let found = -1;
+      for (let k = 0; k < rawChoices.length; k += 1) {
+        const ro = rawChoices[k];
+        if (ro && typeof ro === 'object' && ro.correct === true) {
+          found = k;
+          break;
+        }
+      }
+      answerIdx = found;
+    } else {
+      answerIdx = -1;
+    }
+
+    const qq = ((q.text || q.title || '') + '').trim();
+    let valid = qq && Array.isArray(choices) && choices.length >= 2;
+
+    if (valid) {
+      for (let e = 0; e < choices.length; e += 1) {
+        if (!choices[e]) {
+          valid = false;
+          break;
+        }
+      }
+    }
+
+    let questionSource = '';
+    if (q && typeof q.source === 'string') questionSource = q.source;
+    else if (q && typeof q.provider === 'string') questionSource = q.provider;
+    questionSource = questionSource ? String(questionSource).toLowerCase() : 'manual';
+
+    let authorNameValue = '';
+    if (q && typeof q.authorName === 'string') authorNameValue = q.authorName.trim();
+    else if (q && typeof q.author === 'string') authorNameValue = q.author.trim();
+    else if (q && typeof q.createdByName === 'string') authorNameValue = q.createdByName.trim();
+    else if (q && typeof q.submittedByName === 'string') authorNameValue = q.submittedByName.trim();
+
+    if (valid && typeof answerIdx === 'number' && answerIdx >= 0 && answerIdx < choices.length) {
+      normalized.push({ q: qq, c: choices, a: answerIdx, authorName: authorNameValue, source: questionSource });
+    }
+  }
+
+  return normalized;
+}
+
+export async function startQuizFromAdmin(arg) {
+  if (typeof Event !== 'undefined' && arg instanceof Event) {
+    try {
+      arg.preventDefault();
+    } catch (_) {}
+    arg = null;
+  }
+
+  const opts = arg && typeof arg === 'object' ? arg : {};
+  const rangeEl = typeof document !== 'undefined' ? document.getElementById('range-count') : null;
+  const rangeVal = rangeEl ? rangeEl.value || rangeEl.getAttribute('value') : null;
+  const count = (opts.count != null ? Number(opts.count) : Number(rangeVal || 5)) || 5;
+
+  const firstCategory = getActiveCategories()[0] || getFirstCategory();
+  const categoryId =
+    opts.categoryId != null ? opts.categoryId : State.quiz?.catId != null ? State.quiz.catId : firstCategory?.id;
+
+  if (!categoryId) {
+    toast('دسته‌ای یافت نشد.');
+    return false;
+  }
+
+  const catObj = findCategoryById(categoryId) || null;
+  const diffPoolRaw = getCategoryDifficultyPool(catObj);
+  const diffPool = Array.isArray(diffPoolRaw) && diffPoolRaw.length ? diffPoolRaw : getEffectiveDiffs();
+
+  const selectedDiff = pickDifficulty(diffPool, {
+    requested: opts.difficulty,
+    stateValue: State.quiz?.diffValue,
+    stateLabel: State.quiz?.diff,
+  });
+
+  const difficultyValue = selectedDiff ? selectedDiff.value : undefined;
+  const difficultyLabel = selectedDiff ? selectedDiff.label || selectedDiff.value : undefined;
+
+  if (selectedDiff) {
+    State.quiz.diffValue = difficultyValue;
+    State.quiz.diff = difficultyLabel || State.quiz.diff || '—';
+  }
+
+  const startBtn = typeof document !== 'undefined' ? document.getElementById('setup-start') : null;
+  const prevDisabled = startBtn ? !!startBtn.disabled : null;
+  if (startBtn) startBtn.disabled = true;
+
+  try {
+    let list = [];
+    if (typeof Api !== 'undefined' && Api && typeof Api.questions === 'function') {
+      list = (await Api.questions({ categoryId, count, difficulty: difficultyValue })) || [];
+    }
+
+    if (!Array.isArray(list) || list.length === 0) {
+      toast('برای این دسته هنوز سوالی ثبت نشده 😕');
+      return false;
+    }
+
+    const normalized = normalizeQuestions(list);
+    if (normalized.length === 0) {
+      toast('سوال معتبر برای این تنظیمات موجود نیست.');
+      return false;
+    }
+
+    const fallbackCat = firstCategory || null;
+    const catMeta = catObj || fallbackCat || {};
+    const stateQuizCat = State.quiz?.cat;
+    const catTitle = opts.cat != null ? opts.cat : catMeta.title || catMeta.name || stateQuizCat || '—';
+
+    if (State.quiz) {
+      State.quiz.catId = categoryId;
+      State.quiz.cat = catTitle;
+    }
+
+    const started = beginQuizSession({
+      cat: catTitle,
+      diff: difficultyLabel,
+      diffValue: difficultyValue,
+      questions: normalized,
+      count,
+      source: opts.source != null ? opts.source : 'setup',
+    });
+
+    return !!started;
+  } catch (err) {
+    if (typeof console !== 'undefined' && console && console.warn) {
+      console.warn('Failed to fetch questions', err);
+    }
+    toast('دریافت سوالات با خطا مواجه شد');
+    return false;
+  } finally {
+    if (startBtn) startBtn.disabled = prevDisabled != null ? prevDisabled : false;
+  }
+}


### PR DESCRIPTION
## Summary
- extract quiz engine utilities into a dedicated module that manages question rendering, lifelines, and dependency wiring
- add a loader module responsible for fetching and normalizing admin questions before starting a quiz session
- update the main entrypoint to use the new modules for quiz start flows and navigation handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf9aee38f08326bc90c87fd27d8112