### PR TITLE
Add JService trivia proxy and client demo

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1447,6 +1447,18 @@
         </div>
       </div>
     </section>
+    <section id="page-jservice-demo" class="space-y-4">
+      <div class="glass rounded-3xl border border-white/10 p-6 shadow-xl space-y-4">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-xl font-extrabold">سوالات سریع جئوپاردی</h2>
+            <p class="text-sm text-white/70 mt-1">سوال‌های تصادفی با گزینه‌های چهارگانه</p>
+          </div>
+          <span class="px-3 py-1 rounded-full bg-white/10 border border-white/20 text-xs text-white/80">JService</span>
+        </div>
+        <div id="quiz-root" class="space-y-4 text-sm text-white/70" aria-live="polite"></div>
+      </div>
+    </section>
   </main>
   
   <!-- Bottom Nav -->
@@ -1789,6 +1801,7 @@
   <!-- Confetti -->
   <canvas id="confetti" class="confetti"></canvas>
   
+<script type="module" src="public/js/jservice.js"></script>
 <script type="module" src="./Iquiz-assets/main.js" defer></script>
 
 </body>

--- a/public/js/jservice.js
+++ b/public/js/jservice.js
@@ -1,0 +1,371 @@
+const API_ENDPOINT = '/api/jservice/random';
+const CLIENT_CACHE_LIMIT = 200;
+const DEFAULT_COUNT = 5;
+const GENERIC_DISTRACTORS = [
+  'Mount Everest',
+  'Photosynthesis',
+  'Alexander Hamilton',
+  'The Pacific Ocean',
+  'Isaac Newton',
+  'Saturn',
+  'The Amazon River',
+  'The Mona Lisa',
+  'Pythagoras',
+  'Silicon Valley',
+  'Mercury',
+  'Neil Armstrong',
+];
+
+const PUNCTUATION_REGEX = /[^\p{L}\p{N}\s]/gu;
+
+/** @typedef {{id:number, category:string, question:string, answer:string, airdate:(string|null|undefined)}} JServiceClue */
+/** @typedef {{id:number, category:string, question:string, options:string[], correctIndex:number}} MultipleChoiceQuestion */
+
+const clueStore = {
+  order: [],
+  byId: new Map(),
+  byCategory: new Map(),
+};
+
+function clampCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_COUNT;
+  return Math.min(Math.max(parsed, 1), 20);
+}
+
+function stripPunctuation(value) {
+  return value.replace(PUNCTUATION_REGEX, ' ');
+}
+
+function sanitizeOption(value) {
+  if (typeof value !== 'string') return '';
+  const stripped = stripPunctuation(value);
+  const normalized = stripped.replace(/\s+/g, ' ').trim();
+  if (normalized) return normalized;
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function getCategoryKey(category) {
+  if (typeof category !== 'string') return '';
+  return category.trim().toLowerCase();
+}
+
+function addToStore(clue) {
+  const idKey = String(clue.id);
+  if (clueStore.byId.has(idKey)) {
+    const index = clueStore.order.indexOf(idKey);
+    if (index !== -1) {
+      clueStore.order.splice(index, 1);
+    }
+  }
+  clueStore.byId.set(idKey, clue);
+  clueStore.order.push(idKey);
+
+  const categoryKey = getCategoryKey(clue.category);
+  if (categoryKey) {
+    let set = clueStore.byCategory.get(categoryKey);
+    if (!set) {
+      set = new Set();
+      clueStore.byCategory.set(categoryKey, set);
+    }
+    set.add(idKey);
+  }
+
+  while (clueStore.order.length > CLIENT_CACHE_LIMIT) {
+    const oldestKey = clueStore.order.shift();
+    if (!oldestKey) break;
+    const existing = clueStore.byId.get(oldestKey);
+    clueStore.byId.delete(oldestKey);
+    if (existing) {
+      const existingCategory = getCategoryKey(existing.category);
+      if (existingCategory) {
+        const set = clueStore.byCategory.get(existingCategory);
+        if (set) {
+          set.delete(oldestKey);
+          if (set.size === 0) {
+            clueStore.byCategory.delete(existingCategory);
+          }
+        }
+      }
+    }
+  }
+}
+
+function updateCache(clues) {
+  clues.forEach((clue) => {
+    if (clue && typeof clue.id === 'number') {
+      addToStore(clue);
+    }
+  });
+}
+
+function gatherCandidateAnswers(clue, correctValue) {
+  const correctLower = correctValue.toLowerCase();
+  const targetLength = correctValue.length;
+  const seen = new Set();
+  const sameCategory = [];
+  const others = [];
+  const categoryKey = getCategoryKey(clue.category);
+  const idKey = String(clue.id);
+  const sameCategorySet = categoryKey ? clueStore.byCategory.get(categoryKey) : null;
+  const addCandidate = (list, answer) => {
+    const option = sanitizeOption(answer);
+    if (!option) return;
+    const normalized = option.toLowerCase();
+    if (normalized === correctLower || seen.has(normalized)) return;
+    seen.add(normalized);
+    list.push({ value: option, weight: Math.abs(option.length - targetLength) });
+  };
+
+  if (sameCategorySet) {
+    sameCategorySet.forEach((candidateId) => {
+      if (candidateId === idKey) return;
+      const stored = clueStore.byId.get(candidateId);
+      if (!stored) {
+        sameCategorySet.delete(candidateId);
+        return;
+      }
+      addCandidate(sameCategory, stored.answer);
+    });
+    if (sameCategorySet.size === 0) {
+      clueStore.byCategory.delete(categoryKey);
+    }
+  }
+
+  clueStore.byId.forEach((stored, candidateId) => {
+    if (candidateId === idKey) return;
+    if (sameCategorySet && sameCategorySet.has(candidateId)) return;
+    addCandidate(others, stored.answer);
+  });
+
+  sameCategory.sort((a, b) => a.weight - b.weight);
+  others.sort((a, b) => a.weight - b.weight);
+
+  return sameCategory.concat(others).map((entry) => entry.value);
+}
+
+function pickDistractors(clue, correctValue) {
+  const candidates = gatherCandidateAnswers(clue, correctValue);
+  const distractors = [];
+
+  candidates.some((candidate) => {
+    distractors.push(candidate);
+    return distractors.length >= 3;
+  });
+
+  if (distractors.length < 3) {
+    for (const fallback of GENERIC_DISTRACTORS) {
+      const sanitized = sanitizeOption(fallback);
+      if (!sanitized) continue;
+      const normalized = sanitized.toLowerCase();
+      if (normalized === correctValue.toLowerCase()) continue;
+      if (distractors.some((item) => item.toLowerCase() === normalized)) continue;
+      distractors.push(sanitized);
+      if (distractors.length >= 3) break;
+    }
+  }
+
+  while (distractors.length < 3) {
+    const filler = `گزینه ${distractors.length + 1}`;
+    if (!distractors.includes(filler) && filler !== correctValue) {
+      distractors.push(filler);
+    } else {
+      distractors.push(`انتخاب ${distractors.length + 1}`);
+    }
+  }
+
+  return distractors;
+}
+
+function shuffle(array) {
+  const result = array.slice();
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * @param {JServiceClue} clue
+ * @returns {MultipleChoiceQuestion}
+ */
+function toMultipleChoice(clue) {
+  const question = typeof clue.question === 'string' ? clue.question.trim() : '';
+  const cleanedAnswer = sanitizeOption(clue.answer);
+  const answer = cleanedAnswer || (typeof clue.answer === 'string' ? clue.answer.trim() : '');
+  const safeAnswer = answer || 'پاسخ نامشخص';
+  const distractors = pickDistractors(clue, safeAnswer);
+  const options = shuffle([...distractors, safeAnswer]);
+  const correctIndex = options.findIndex((item) => item === safeAnswer);
+  return {
+    id: clue.id,
+    category: clue.category,
+    question: question || 'سوال نامشخص',
+    options,
+    correctIndex: correctIndex === -1 ? options.length - 1 : correctIndex,
+  };
+}
+
+async function requestRandomClues(count) {
+  const response = await fetch(`${API_ENDPOINT}?count=${count}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    const error = new Error(`Failed to load clues (${response.status})`);
+    error.status = response.status;
+    throw error;
+  }
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    const error = new Error('Failed to parse trivia response');
+    error.cause = err;
+    throw error;
+  }
+  const data = Array.isArray(payload?.data) ? payload.data : [];
+  updateCache(data);
+  return data;
+}
+
+/**
+ * Fetch MCQ set from server.
+ * @param {number} [count=5]
+ * @returns {Promise<MultipleChoiceQuestion[]>}
+ */
+export async function getRandomMCQs(count = DEFAULT_COUNT) {
+  const normalizedCount = clampCount(count);
+  const clues = await requestRandomClues(normalizedCount);
+  return clues.map((clue) => toMultipleChoice(clue));
+}
+
+function renderError(root, retry) {
+  root.innerHTML = '';
+  const card = document.createElement('div');
+  card.className = 'glass-dark rounded-3xl border border-rose-400/40 bg-rose-500/10 p-5 text-sm text-white/80 space-y-3';
+  const message = document.createElement('p');
+  message.textContent = 'امکان دریافت سوال از سرویس جئوپاردی وجود ندارد.';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20 border border-white/20 transition';
+  button.textContent = 'تلاش مجدد';
+  button.addEventListener('click', () => {
+    if (typeof retry === 'function') {
+      retry();
+    }
+  });
+  card.append(message, button);
+  root.append(card);
+}
+
+function renderMCQ(mcq, root, refresh) {
+  root.innerHTML = '';
+  const card = document.createElement('div');
+  card.className = 'glass-dark rounded-3xl border border-white/10 p-6 space-y-5 shadow-xl';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between gap-3 text-xs text-white/70';
+  const categoryBadge = document.createElement('span');
+  categoryBadge.className = 'px-3 py-1 rounded-full bg-white/10 border border-white/20 font-semibold text-white/90';
+  categoryBadge.textContent = mcq.category || 'عمومی';
+  header.appendChild(categoryBadge);
+
+  if (typeof refresh === 'function') {
+    const refreshButton = document.createElement('button');
+    refreshButton.type = 'button';
+    refreshButton.className = 'px-3 py-1 rounded-full border border-white/20 bg-white/5 hover:bg-white/10 transition text-white/90 flex items-center gap-2';
+    refreshButton.innerHTML = '<span class="hidden sm:inline">سوال جدید</span><i class="fas fa-sync-alt"></i>';
+    refreshButton.addEventListener('click', () => {
+      refreshButton.disabled = true;
+      refreshButton.classList.add('opacity-60');
+      refresh();
+    });
+    header.appendChild(refreshButton);
+  }
+
+  const questionEl = document.createElement('h3');
+  questionEl.className = 'text-lg font-extrabold leading-8 text-white';
+  questionEl.textContent = mcq.question;
+
+  const optionsContainer = document.createElement('div');
+  optionsContainer.className = 'grid grid-cols-1 gap-3';
+
+  const statusEl = document.createElement('p');
+  statusEl.className = 'text-sm text-white/80 min-h-[1.5rem]';
+  statusEl.setAttribute('role', 'status');
+  statusEl.setAttribute('aria-live', 'polite');
+
+  const buttons = [];
+  let revealed = false;
+
+  const reveal = (selectedIndex) => {
+    if (revealed) return;
+    revealed = true;
+    buttons.forEach((button, idx) => {
+      button.disabled = true;
+      button.classList.remove('hover:bg-white/10');
+      if (idx === mcq.correctIndex) {
+        button.classList.add('border-emerald-400', 'bg-emerald-500/20', 'text-emerald-100');
+      } else if (idx === selectedIndex) {
+        button.classList.add('border-rose-400', 'bg-rose-500/20', 'text-rose-100');
+      } else {
+        button.classList.add('opacity-70');
+      }
+    });
+    if (selectedIndex === mcq.correctIndex) {
+      statusEl.textContent = 'آفرین! پاسخ درست بود.';
+    } else {
+      statusEl.textContent = `پاسخ درست: ${mcq.options[mcq.correctIndex]}`;
+    }
+  };
+
+  mcq.options.forEach((option, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'flex items-center justify-between gap-3 w-full text-right px-4 py-3 rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-sky-400';
+
+    const letter = document.createElement('span');
+    letter.className = 'w-8 h-8 rounded-full bg-white/10 border border-white/20 flex items-center justify-center font-semibold text-white/90';
+    letter.textContent = String.fromCharCode(65 + index);
+
+    const text = document.createElement('span');
+    text.className = 'flex-1 text-sm text-white';
+    text.textContent = option;
+
+    button.append(letter, text);
+    button.addEventListener('click', () => reveal(index));
+
+    buttons.push(button);
+    optionsContainer.appendChild(button);
+  });
+
+  card.append(header, questionEl, optionsContainer, statusEl);
+  root.append(card);
+}
+
+async function loadAndRender(root) {
+  root.innerHTML = '<div class="glass-dark rounded-3xl border border-white/10 p-5 text-sm text-white/70">در حال بارگذاری سوال...</div>';
+  try {
+    const mcqs = await getRandomMCQs();
+    const mcq = mcqs[0];
+    if (!mcq) {
+      const emptyState = document.createElement('div');
+      emptyState.className = 'glass-dark rounded-3xl border border-white/10 p-5 text-sm text-white/70';
+      emptyState.textContent = 'سوالی یافت نشد. بعداً دوباره تلاش کنید.';
+      root.innerHTML = '';
+      root.append(emptyState);
+      return;
+    }
+    renderMCQ(mcq, root, () => loadAndRender(root));
+  } catch (error) {
+    console.error(error);
+    renderError(root, () => loadAndRender(root));
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.getElementById('quiz-root');
+  if (!root) return;
+  loadAndRender(root);
+});

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -15,6 +15,7 @@ const connectDB = require('./config/db');
 const logger = require('./config/logger');
 const errorHandler = require('./middleware/error');
 const triviaRoutes = require('./routes/trivia');
+const jserviceRoutes = require('./routes/jservice.routes');
 const { startTriviaPoller } = require('./poller/triviaPoller');
 const { ensureInitialCategories, syncProviderCategories } = require('./services/categorySeeder');
 
@@ -95,6 +96,7 @@ app.use('/api/achievements', require('./routes/achievements.routes'));
 app.use('/api/ads', require('./routes/ads.routes'));
 app.use('/api/public', require('./routes/public.routes'));
 app.use('/api/trivia', triviaRoutes);
+app.use('/api/jservice', jserviceRoutes);
 app.use('/api', require('./routes/trivia-triviaapi'));
 
 // error handler

--- a/server/src/lib/lruCache.js
+++ b/server/src/lib/lruCache.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Simple LRU cache with TTL support.
+ */
+class LruCache {
+  /**
+   * @param {object} [options]
+   * @param {number} [options.max=200]
+   * @param {number} [options.ttl=600000]
+   */
+  constructor(options = {}) {
+    const { max = 200, ttl = 600000 } = options;
+    this.max = Number.isFinite(max) && max > 0 ? Math.floor(max) : 200;
+    this.ttl = Number.isFinite(ttl) && ttl > 0 ? ttl : 600000;
+    /** @type {Map<string|number, {value: any, expiresAt: number}>} */
+    this.store = new Map();
+  }
+
+  /** @returns {number} */
+  _now() {
+    return Date.now();
+  }
+
+  /**
+   * Remove expired entries from cache.
+   * @param {number} [nowTs]
+   * @returns {{key: string|number, value: any}[]}
+   */
+  prune(nowTs = this._now()) {
+    const removed = [];
+    for (const [key, entry] of this.store.entries()) {
+      if (entry.expiresAt <= nowTs) {
+        this.store.delete(key);
+        removed.push({ key, value: entry.value });
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * Store value in cache.
+   * @param {string|number} key
+   * @param {any} value
+   * @returns {{key: string|number, value: any}[]}
+   */
+  set(key, value) {
+    const removed = this.prune();
+    if (this.store.has(key)) {
+      this.store.delete(key);
+    }
+
+    this.store.set(key, { value, expiresAt: this._now() + this.ttl });
+
+    while (this.store.size > this.max) {
+      const oldest = this.store.entries().next().value;
+      if (!oldest) break;
+      const [oldKey, oldEntry] = oldest;
+      this.store.delete(oldKey);
+      removed.push({ key: oldKey, value: oldEntry.value });
+    }
+
+    return removed;
+  }
+
+  /**
+   * Retrieve value and mark as recently used.
+   * @param {string|number} key
+   * @returns {any|null}
+   */
+  get(key) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= this._now()) {
+      this.store.delete(key);
+      return null;
+    }
+
+    this.store.delete(key);
+    this.store.set(key, entry);
+    return entry.value;
+  }
+
+  /**
+   * Read value without affecting recency.
+   * @param {string|number} key
+   * @returns {any|null}
+   */
+  peek(key) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= this._now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  /**
+   * Check whether cache contains key.
+   * @param {string|number} key
+   * @returns {boolean}
+   */
+  has(key) {
+    return this.peek(key) !== null;
+  }
+
+  /**
+   * Delete entry by key.
+   * @param {string|number} key
+   * @returns {any|null}
+   */
+  delete(key) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    this.store.delete(key);
+    return entry.value;
+  }
+
+  /**
+   * Clear cache.
+   */
+  clear() {
+    this.store.clear();
+  }
+
+  /**
+   * Get cached values.
+   * @returns {any[]}
+   */
+  values() {
+    this.prune();
+    return Array.from(this.store.values(), (entry) => entry.value);
+  }
+
+  /**
+   * Number of stored items.
+   * @returns {number}
+   */
+  size() {
+    this.prune();
+    return this.store.size;
+  }
+}
+
+module.exports = LruCache;

--- a/server/src/routes/jservice.routes.js
+++ b/server/src/routes/jservice.routes.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const router = require('express').Router();
+
+const { getRandomClues, clampCount, getCacheSnapshot } = require('../services/jservice');
+
+router.get('/random', async (req, res, next) => {
+  const count = clampCount(req.query.count);
+  try {
+    const clues = await getRandomClues(count);
+    res.json({
+      ok: true,
+      data: clues,
+      meta: {
+        requested: count,
+        delivered: clues.length,
+        cacheSize: getCacheSnapshot().size,
+      },
+    });
+  } catch (error) {
+    if (!error.statusCode) {
+      error.statusCode = 502;
+    }
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/src/services/jservice/cache.js
+++ b/server/src/services/jservice/cache.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const LruCache = require('../../lib/lruCache');
+
+/**
+ * Cache wrapper for JService clues with category indexing.
+ */
+class JServiceCache {
+  /**
+   * @param {object} [options]
+   * @param {number} [options.maxSize=200]
+   * @param {number} [options.ttl=600000]
+   */
+  constructor(options = {}) {
+    const { maxSize = 200, ttl = 600000 } = options;
+    this.cache = new LruCache({ max: maxSize, ttl });
+    /** @type {Map<string, Set<number>>} */
+    this.categoryIndex = new Map();
+  }
+
+  /**
+   * @param {number|string|{categoryId?: number, category?: string}} source
+   * @returns {string[]}
+   */
+  _categoryKeys(source) {
+    if (source == null) return [];
+    if (typeof source === 'number' && Number.isFinite(source)) {
+      return [`id:${source}`];
+    }
+    if (typeof source === 'string') {
+      const normalized = source.trim();
+      if (!normalized) return [];
+      if (/^id:\d+$/.test(normalized)) return [normalized];
+      return [`name:${normalized.toLowerCase()}`];
+    }
+    const keys = [];
+    const { categoryId, category } = source;
+    if (Number.isFinite(categoryId)) {
+      keys.push(`id:${categoryId}`);
+    }
+    if (typeof category === 'string' && category.trim()) {
+      keys.push(`name:${category.trim().toLowerCase()}`);
+    }
+    return keys;
+  }
+
+  /**
+   * Remove clue from category index.
+   * @param {{id:number, categoryId?:number, category?:string}} clue
+   */
+  _removeFromIndex(clue) {
+    const keys = this._categoryKeys(clue);
+    keys.forEach((key) => {
+      const set = this.categoryIndex.get(key);
+      if (!set) return;
+      set.delete(clue.id);
+      if (set.size === 0) {
+        this.categoryIndex.delete(key);
+      }
+    });
+  }
+
+  /**
+   * Add clue to category index.
+   * @param {{id:number, categoryId?:number, category?:string}} clue
+   */
+  _addToIndex(clue) {
+    const keys = this._categoryKeys(clue);
+    keys.forEach((key) => {
+      if (!key) return;
+      let set = this.categoryIndex.get(key);
+      if (!set) {
+        set = new Set();
+        this.categoryIndex.set(key, set);
+      }
+      set.add(clue.id);
+    });
+  }
+
+  _purgeExpired() {
+    const removed = this.cache.prune();
+    removed.forEach(({ value }) => {
+      if (value && typeof value.id === 'number') {
+        this._removeFromIndex(value);
+      }
+    });
+  }
+
+  /**
+   * Store clue in cache.
+   * @param {{id:number, categoryId?:number, category?:string}} clue
+   */
+  set(clue) {
+    if (!clue || typeof clue.id !== 'number') return;
+    this._purgeExpired();
+    const existing = this.cache.peek(clue.id);
+    if (existing) {
+      this._removeFromIndex(existing);
+    }
+    const removed = this.cache.set(clue.id, clue);
+    removed.forEach(({ value }) => {
+      if (value) this._removeFromIndex(value);
+    });
+    this._addToIndex(clue);
+  }
+
+  /**
+   * Check whether clue exists.
+   * @param {number} id
+   * @returns {boolean}
+   */
+  has(id) {
+    this._purgeExpired();
+    return this.cache.has(id);
+  }
+
+  /**
+   * Get clue by id.
+   * @param {number} id
+   * @returns {object|null}
+   */
+  get(id) {
+    this._purgeExpired();
+    return this.cache.get(id);
+  }
+
+  /**
+   * Return array of clues for category.
+   * @param {number|string|{categoryId?:number, category?:string}} category
+   * @param {object} [options]
+   * @param {Set<number>|number[]} [options.exclude]
+   * @returns {object[]}
+   */
+  getByCategory(category, options = {}) {
+    this._purgeExpired();
+    const keys = this._categoryKeys(category);
+    if (keys.length === 0) return [];
+    const excludeSet = options.exclude instanceof Set
+      ? options.exclude
+      : Array.isArray(options.exclude)
+        ? new Set(options.exclude)
+        : new Set();
+
+    const results = [];
+    const seen = new Set();
+
+    keys.forEach((key) => {
+      const ids = this.categoryIndex.get(key);
+      if (!ids) return;
+      ids.forEach((clueId) => {
+        if (excludeSet.has(clueId) || seen.has(clueId)) return;
+        const clue = this.cache.peek(clueId);
+        if (!clue) {
+          ids.delete(clueId);
+          return;
+        }
+        seen.add(clueId);
+        results.push(clue);
+      });
+      if (ids.size === 0) {
+        this.categoryIndex.delete(key);
+      }
+    });
+
+    return results;
+  }
+
+  /**
+   * All cached clues.
+   * @returns {object[]}
+   */
+  getAll() {
+    this._purgeExpired();
+    return this.cache.values();
+  }
+
+  /**
+   * Current cache size.
+   * @returns {number}
+   */
+  size() {
+    this._purgeExpired();
+    return this.cache.size();
+  }
+}
+
+module.exports = JServiceCache;

--- a/server/src/services/jservice/client.js
+++ b/server/src/services/jservice/client.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const { fetchWithRetry } = require('../../lib/http');
+
+const API_ENDPOINT = 'http://jservice.io/api/random';
+const MAX_BATCH = 100;
+const RETRY_DELAYS = [250, 500, 1000];
+
+const NAMED_ENTITIES = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  lsquo: '‘',
+  rsquo: '’',
+  ldquo: '“',
+  rdquo: '”',
+  ndash: '–',
+  mdash: '—',
+  hellip: '…',
+  copy: '©',
+  reg: '®',
+  trade: '™',
+  euro: '€',
+  pound: '£',
+  yen: '¥',
+  rs: '₹',
+  deg: '°',
+  plusmn: '±',
+  frac12: '½',
+  frac14: '¼',
+  frac34: '¾',
+  times: '×',
+  divide: '÷',
+};
+
+/**
+ * Decode HTML entities.
+ * @param {string} value
+ * @returns {string}
+ */
+function decodeHtmlEntities(value) {
+  if (typeof value !== 'string' || value.indexOf('&') === -1) {
+    return typeof value === 'string' ? value : '';
+  }
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity) => {
+    if (entity[0] === '#') {
+      const isHex = entity[1] === 'x' || entity[1] === 'X';
+      const num = isHex ? Number.parseInt(entity.slice(2), 16) : Number.parseInt(entity.slice(1), 10);
+      if (Number.isFinite(num)) {
+        try {
+          return String.fromCodePoint(num);
+        } catch (err) {
+          return match;
+        }
+      }
+      return match;
+    }
+    const replacement = NAMED_ENTITIES[entity.toLowerCase()];
+    return typeof replacement === 'string' ? replacement : match;
+  });
+}
+
+/**
+ * Normalize text by decoding HTML entities, stripping tags and collapsing whitespace.
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeText(value) {
+  if (typeof value !== 'string') return '';
+  const decoded = decodeHtmlEntities(value);
+  const withoutTags = decoded.replace(/<[^>]+>/g, ' ');
+  return withoutTags.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Normalize airdate to ISO string.
+ * @param {string|null} airdate
+ * @returns {string|null}
+ */
+function normalizeAirdate(airdate) {
+  if (!airdate) return null;
+  const ts = Date.parse(airdate);
+  if (!Number.isFinite(ts)) return null;
+  try {
+    return new Date(ts).toISOString();
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * @param {object} raw
+ * @returns {{id:number, categoryId:number|null, category:string, question:string, answer:string, airdate:string|null}|null}
+ */
+function normalizeClue(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = Number.parseInt(raw.id, 10);
+  if (!Number.isFinite(id)) return null;
+  const question = normalizeText(raw.question || '');
+  const answer = normalizeText(raw.answer || '');
+  if (!question || !answer) return null;
+  const categoryIdRaw = raw.category && Number.parseInt(raw.category.id, 10);
+  const categoryTitleRaw = raw.category && raw.category.title;
+  const categoryTitle = normalizeText(categoryTitleRaw || '');
+  return {
+    id,
+    categoryId: Number.isFinite(categoryIdRaw) ? categoryIdRaw : null,
+    category: categoryTitle || 'General',
+    question,
+    answer,
+    airdate: normalizeAirdate(raw.airdate || null)
+  };
+}
+
+/**
+ * @param {number} count
+ * @returns {Promise<object[]>}
+ */
+async function fetchRandomClues(count) {
+  const size = Math.min(Math.max(Math.floor(count) || 1, 1), MAX_BATCH);
+  const url = `${API_ENDPOINT}?count=${size}`;
+  let response;
+  try {
+    response = await fetchWithRetry(url, {
+      headers: { Accept: 'application/json' },
+      retries: RETRY_DELAYS.length,
+      retryDelay: ({ attempt }) => RETRY_DELAYS[Math.min(attempt - 1, RETRY_DELAYS.length - 1)],
+      retryOn: (res) => res && (res.status >= 500 || res.status === 429 || res.status === 408),
+      timeout: 8000,
+    });
+  } catch (error) {
+    const err = new Error(`Failed to reach JService: ${error.message}`);
+    err.cause = error;
+    throw err;
+  }
+
+  if (!response.ok) {
+    const err = new Error(`JService responded with status ${response.status}`);
+    err.status = response.status;
+    throw err;
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    const err = new Error('Failed to parse JService response');
+    err.cause = error;
+    throw err;
+  }
+
+  const items = Array.isArray(payload) ? payload : [];
+  const normalized = [];
+  items.forEach((item) => {
+    const clue = normalizeClue(item);
+    if (clue) normalized.push(clue);
+  });
+
+  return normalized;
+}
+
+module.exports = {
+  fetchRandomClues,
+  normalizeClue,
+  decodeHtmlEntities,
+  normalizeText,
+};

--- a/server/src/services/jservice/index.js
+++ b/server/src/services/jservice/index.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const JServiceCache = require('./cache');
+const { fetchRandomClues } = require('./client');
+
+const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+const CACHE_MAX = 200;
+const MAX_REQUEST = 20;
+const MAX_FETCH_ATTEMPTS = 4;
+
+const cache = new JServiceCache({ maxSize: CACHE_MAX, ttl: CACHE_TTL });
+
+/**
+ * Clamp count to supported range.
+ * @param {number} value
+ * @returns {number}
+ */
+function clampCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 5;
+  return Math.min(Math.max(parsed, 1), MAX_REQUEST);
+}
+
+/**
+ * Normalize clue for API response.
+ * @param {{id:number, category:string, question:string, answer:string, airdate:string|null}} clue
+ * @returns {{id:number, category:string, question:string, answer:string, airdate:string|null}}
+ */
+function mapForResponse(clue) {
+  return {
+    id: clue.id,
+    category: clue.category,
+    question: clue.question,
+    answer: clue.answer,
+    airdate: clue.airdate || null,
+  };
+}
+
+/**
+ * Fetch random clues with caching and de-duplication.
+ * @param {number} count
+ * @returns {Promise<object[]>}
+ */
+async function getRandomClues(count) {
+  const desired = clampCount(count);
+  const unique = new Map();
+  const duplicates = [];
+  const fetched = new Map();
+  let attempts = 0;
+
+  while (unique.size < desired && attempts < MAX_FETCH_ATTEMPTS) {
+    const remaining = desired - unique.size;
+    const batchSize = Math.min(Math.max(remaining + 2, 1), MAX_REQUEST * 2);
+    let batch;
+    try {
+      batch = await fetchRandomClues(batchSize);
+    } catch (error) {
+      if (unique.size === 0) {
+        throw error;
+      }
+      break;
+    }
+    attempts += 1;
+
+    batch.forEach((clue) => {
+      fetched.set(clue.id, clue);
+      if (unique.has(clue.id)) return;
+      if (!cache.has(clue.id)) {
+        unique.set(clue.id, clue);
+      } else {
+        duplicates.push(clue);
+      }
+    });
+  }
+
+  for (const clue of duplicates) {
+    if (unique.size >= desired) break;
+    unique.set(clue.id, clue);
+  }
+
+  if (unique.size < desired) {
+    cache.getAll().some((clue) => {
+      if (unique.has(clue.id)) return false;
+      unique.set(clue.id, clue);
+      return unique.size >= desired;
+    });
+  }
+
+  const result = Array.from(unique.values()).slice(0, desired);
+
+  const persist = new Map();
+  result.forEach((clue) => persist.set(clue.id, clue));
+  fetched.forEach((clue, id) => {
+    if (!persist.has(id)) {
+      persist.set(id, clue);
+    }
+  });
+  persist.forEach((clue) => cache.set(clue));
+
+  return result.map(mapForResponse);
+}
+
+function getCacheSnapshot() {
+  return {
+    size: cache.size(),
+  };
+}
+
+module.exports = {
+  getRandomClues,
+  getCacheSnapshot,
+  clampCount,
+};


### PR DESCRIPTION
## Summary
- add a JService fetcher with HTML decoding, retry logic, and LRU-backed cache to serve normalized clues from `/api/jservice/random`
- expose a browser module that converts clues into multiple choice questions, maintains a client-side pool for distractors, and renders a demo quiz widget
- extend the bot UI with a Jeopardy trivia section and load the new script

## Testing
- node --check server/src/services/jservice/client.js
- node --check server/src/services/jservice/cache.js
- node --check server/src/services/jservice/index.js
- node --check server/src/lib/lruCache.js
- node --check server/src/routes/jservice.routes.js
- node --check public/js/jservice.js

------
https://chatgpt.com/codex/tasks/task_e_68cfa829e8f88326b02679f4ffb01a3a