### PR TITLE
Normalize trivia provider aliases on the server

### DIFF
--- a/server/src/services/triviaProviders.js
+++ b/server/src/services/triviaProviders.js
@@ -42,9 +42,29 @@ const TRIVIA_PROVIDERS = [
   }
 ];
 
+const PROVIDER_ID_ALIASES = Object.freeze({
+  opentdb: 'opentdb',
+  'open-trivia-db': 'opentdb',
+  'open_trivia_db': 'opentdb',
+  'open trivia db': 'opentdb',
+  'open trivia database': 'opentdb',
+  'the-trivia-api': 'the-trivia-api',
+  triviaapi: 'the-trivia-api',
+  thetriviaapi: 'the-trivia-api',
+  'the trivia api': 'the-trivia-api',
+  'the-triviaapi': 'the-trivia-api',
+  'the trivia-api': 'the-trivia-api',
+  jservice: 'jservice',
+  'j-service': 'jservice',
+  'j_service': 'jservice',
+  'j service': 'jservice',
+  jeopardy: 'jservice',
+});
+
 function normalizeProviderId(value) {
   if (!value) return '';
-  return String(value).trim().toLowerCase();
+  const normalized = String(value).trim().toLowerCase();
+  return PROVIDER_ID_ALIASES[normalized] || normalized;
 }
 
 function listTriviaProviders() {


### PR DESCRIPTION
## Summary
- map common alias spellings for trivia providers to their canonical IDs on the server
- ensure requests that specify JService (and other providers) using alternative names no longer trigger "Unsupported trivia provider"

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfb4c772248326bda8259ce43b4239