### PR TITLE
Normalize provider before trivia import

### DIFF
--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -3616,6 +3616,13 @@ if (triviaImportBtn) {
         provider: providerId,
         amount,
       };
+      const normalizedProvider = resolveProviderId(payload.provider);
+      if (!normalizedProvider) {
+        showToast('منبع سوال انتخاب‌شده معتبر نیست', 'error');
+        setTriviaStatusBadge('error', 'خطا در انتخاب منبع');
+        return;
+      }
+      payload.provider = normalizedProvider;
       if (supportsCategories) {
         payload.categories = Array.from(triviaControlState.selectedCategories);
       }


### PR DESCRIPTION
## Summary
- normalize the provider identifier before submitting trivia import requests
- reuse the existing invalid-provider feedback when normalization fails

## Testing
- not run (UI interaction required for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68cfba02d14c832681e4234d36bcbb3b