### PR TITLE
Fix JService integration

### DIFF
--- a/public/js/jservice.js
+++ b/public/js/jservice.js
@@ -18,7 +18,7 @@ const GENERIC_DISTRACTORS = [
 
 const PUNCTUATION_REGEX = /[^\p{L}\p{N}\s]/gu;
 
-/** @typedef {{id:number, category:string, question:string, answer:string, airdate:(string|null|undefined)}} JServiceClue */
+/** @typedef {{id:number, category:{id:(number|null), title:string, clues_count?:number}|string, question:string, answer:string, airdate:(string|null|undefined), value:(number|null|undefined)}} JServiceClue */
 /** @typedef {{id:number, category:string, question:string, options:string[], correctIndex:number}} MultipleChoiceQuestion */
 
 const clueStore = {
@@ -45,9 +45,20 @@ function sanitizeOption(value) {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+function getCategoryTitle(category) {
+  if (typeof category === 'string') {
+    return category.trim();
+  }
+  if (category && typeof category === 'object' && typeof category.title === 'string') {
+    return category.title.trim();
+  }
+  return '';
+}
+
 function getCategoryKey(category) {
-  if (typeof category !== 'string') return '';
-  return category.trim().toLowerCase();
+  const title = getCategoryTitle(category);
+  if (!title) return '';
+  return title.toLowerCase();
 }
 
 function addToStore(clue) {
@@ -198,9 +209,10 @@ function toMultipleChoice(clue) {
   const distractors = pickDistractors(clue, safeAnswer);
   const options = shuffle([...distractors, safeAnswer]);
   const correctIndex = options.findIndex((item) => item === safeAnswer);
+  const categoryTitle = getCategoryTitle(clue.category);
   return {
     id: clue.id,
-    category: clue.category,
+    category: categoryTitle || 'عمومی',
     question: question || 'سوال نامشخص',
     options,
     correctIndex: correctIndex === -1 ? options.length - 1 : correctIndex,

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node src/index.js",
-    "seed:admin": "node src/seed/createAdmin.js"
+    "seed:admin": "node src/seed/createAdmin.js",
+    "test:jservice": "curl -sf http://localhost:4000/api/jservice/random?count=1 | node -e \"const fs=require('fs');function fail(msg){console.error(msg);process.exit(1);}let raw='';try{raw=fs.readFileSync(0,'utf8');}catch(err){fail('Failed to read response');}if(!raw){fail('Empty response');}let payload;try{payload=JSON.parse(raw);}catch(err){fail('Invalid JSON');}const data=Array.isArray(payload?.data)?payload.data:[];if(!data.length){fail('Missing data');}const clue=data[0];if(!Number.isFinite(clue?.id)){fail('Invalid id');}if(typeof clue.question!=='string'||!clue.question.trim()){fail('Invalid question');}if(typeof clue.answer!=='string'||!clue.answer.trim()){fail('Invalid answer');}if(!clue.category||typeof clue.category.title!=='string'||!clue.category.title.trim()){fail('Invalid category.title');}\""
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -6,7 +6,8 @@ const DEFAULT_MONGO_URI = 'mongodb://localhost:27017/iquiz';
 const DEFAULT_TRIVIA_URL = 'https://opentdb.com/api.php?amount=20&type=multiple';
 const DEFAULT_TRIVIA_INTERVAL = 5000;
 const DEFAULT_THE_TRIVIA_URL = 'https://the-trivia-api.com/v2/questions?limit=20';
-const DEFAULT_JSERVICE_URL = 'https://jservice.io/api/random';
+const JSERVICE_BASE = process.env.JSERVICE_BASE || 'http://jservice.io/api';
+const DEFAULT_JSERVICE_URL = `${JSERVICE_BASE.replace(/\/+$/, '')}/random`;
 const DEFAULT_MONGO_MAX_POOL = 10;
 
 const truthyValues = new Set(['true', '1', 'yes', 'y', 'on']);
@@ -55,6 +56,7 @@ const pollerMaxRuns = pollerMaxRunsCandidate > 0 ? Math.floor(pollerMaxRunsCandi
 const triviaUrl = process.env.TRIVIA_URL || DEFAULT_TRIVIA_URL;
 const theTriviaUrl = process.env.THETRIVIA_URL || DEFAULT_THE_TRIVIA_URL;
 const jserviceUrl = process.env.JSERVICE_URL || DEFAULT_JSERVICE_URL;
+const jserviceBase = JSERVICE_BASE;
 const port = parseNumber(process.env.PORT, DEFAULT_PORT, { min: 1 });
 const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
 
@@ -72,7 +74,8 @@ const env = {
     pollerMaxRuns,
     url: triviaUrl,
     theTriviaUrl,
-    jserviceUrl
+    jserviceUrl,
+    jserviceBase,
   },
   cors: {
     allowedOrigins

--- a/server/src/services/triviaImporter.js
+++ b/server/src/services/triviaImporter.js
@@ -5,7 +5,7 @@ const Question = require('../models/Question');
 const Category = require('../models/Category');
 const { getTriviaProviderById, normalizeProviderId } = require('./triviaProviders');
 const { getFromTheTriviaAPI } = require('../providers/thetrivia');
-const { fetchRandomClues: fetchJServiceRandomClues } = require('./jservice/client');
+const { random: fetchJServiceRandomClues } = require('./jservice/client');
 
 const ALLOWED_DIFFICULTIES = new Set(['easy', 'medium', 'hard']);
 const HTML_ENTITY_MAP = {


### PR DESCRIPTION
## Summary
- add support for configuring the JService base URL and expose it through the env config
- refactor the JService client/service to share a common proxy with random, clues, and categories helpers backed by the new base URL
- expand the express routes, trivia importer, and browser client to use the new API shape and ensure category titles are handled correctly
- add a test:jservice npm script that validates the random endpoint schema

## Testing
- not run (requires API server and MongoDB instance)


------
https://chatgpt.com/codex/tasks/task_e_68cfc3d25d2c83268aac29b7b01a837e