### PR TITLE
Use HTTPS fallback for JService client

### DIFF
--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -6,7 +6,7 @@ const DEFAULT_MONGO_URI = 'mongodb://localhost:27017/iquiz';
 const DEFAULT_TRIVIA_URL = 'https://opentdb.com/api.php?amount=20&type=multiple';
 const DEFAULT_TRIVIA_INTERVAL = 5000;
 const DEFAULT_THE_TRIVIA_URL = 'https://the-trivia-api.com/v2/questions?limit=20';
-const JSERVICE_BASE = process.env.JSERVICE_BASE || 'http://jservice.io/api';
+const JSERVICE_BASE = process.env.JSERVICE_BASE || 'https://jservice.io/api';
 const DEFAULT_JSERVICE_URL = `${JSERVICE_BASE.replace(/\/+$/, '')}/random`;
 const DEFAULT_MONGO_MAX_POOL = 10;
 

--- a/server/src/services/jservice/client.js
+++ b/server/src/services/jservice/client.js
@@ -5,7 +5,7 @@ const zlib = require('zlib');
 const env = require('../../config/env');
 const { fetchWithRetry } = require('../../lib/http');
 
-const DEFAULT_BASE_URL = 'http://jservice.io/api';
+const DEFAULT_BASE_URL = 'https://jservice.io/api';
 const CONFIGURED_BASE = env && env.trivia && env.trivia.jserviceBase;
 const JSERVICE_BASE = (CONFIGURED_BASE || DEFAULT_BASE_URL).replace(/\/+$/, '');
 const MAX_BATCH = 100;


### PR DESCRIPTION
## Summary
- update the server env configuration to default JSERVICE_BASE to the HTTPS endpoint
- mirror the HTTPS fallback in the runtime JService client so both layers align

## Testing
- node -e "const { random } = require('./server/src/services/jservice/client'); (async () => { const results = await random(1); if (!Array.isArray(results) || results.length === 0) { throw new Error('No clues received'); } console.log('Received clue id:', results[0].id); })();" *(fails in sandbox: ENETUNREACH to jservice.io)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcb2283ac8326818086ab026e66d2