### PR TITLE
Gracefully handle misreported JService compression

### DIFF
--- a/server/src/services/jservice/client.js
+++ b/server/src/services/jservice/client.js
@@ -238,6 +238,14 @@ function decodeResponseBuffer(buffer, encoding) {
       }
     }
   } catch (error) {
+    // Some JService responses incorrectly advertise compression even though the
+    // payload is plain text. Attempting to decompress such responses throws a
+    // `Z_DATA_ERROR`. In that case we gracefully fall back to treating the
+    // buffer as an uncompressed UTF-8 string instead of failing the request.
+    if (error && (error.code === 'Z_DATA_ERROR' || error.code === 'ERR_Z_DATA_ERROR' || error.errno === -3)) {
+      return buffer.toString('utf8');
+    }
+
     const err = new Error('Failed to decode JService response');
     err.cause = error;
     throw err;


### PR DESCRIPTION
## Summary
- fall back to plain UTF-8 text when JService advertises compression but sends an uncompressed payload
- prevent trivia imports from failing with `Failed to decode JService response`

## Testing
- ⚠️ `node -e "(async () => { const { random } = require('./server/src/services/jservice/client'); const data = await random(1); console.log('clues', data.length); console.log(data[0]); })().catch(err => { console.error(err); process.exit(1); });"` *(fails: ENETUNREACH when contacting jservice.io from the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcc5bcd748326a0f8a3169f1d9ad5