### PR TITLE
Prevent cached API responses in admin panel

### DIFF
--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -2114,11 +2114,17 @@ function setToken(t) { localStorage.setItem('iq_admin_token', t); }
 function logout() { localStorage.removeItem('iq_admin_token'); location.reload(); }
 
 async function api(path, options = {}) {
-  const headers = options.headers || {};
+  const headers = options.headers ? { ...options.headers } : {};
   const token = getToken();
   if (token) headers['Authorization'] = 'Bearer ' + token;
   headers['Content-Type'] = 'application/json';
-  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+
+  const fetchOptions = { ...options, headers };
+  if (!fetchOptions.cache) {
+    fetchOptions.cache = 'no-store';
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, fetchOptions);
   if (!res.ok) {
     const err = await res.json().catch(()=>({message:'Request failed'}));
     throw new Error(err.message || 'Request failed');


### PR DESCRIPTION
## Summary
- prevent stale data when reloading admin resources by cloning provided headers before attaching auth
- default all admin API requests to `cache: 'no-store'` so browsers always fetch fresh data instead of serving cached responses

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd5c6b058832689ee3f32d512d191