### PR TITLE
Enable JService question provider management

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -1733,7 +1733,7 @@
 
         <!-- Filters -->
         <div class="glass rounded-2xl p-4">
-          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4">
             <div>
               <label class="block text-sm mb-1">دسته‌بندی</label>
               <select id="filter-category" class="form-select">
@@ -1747,6 +1747,17 @@
                 <option value="easy">آسون</option>
                 <option value="medium">متوسط</option>
                 <option value="hard">سخت</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm mb-1">منبع</label>
+              <select id="filter-provider" class="form-select">
+                <option value="">همه منابع</option>
+                <option value="opentdb">OpenTDB</option>
+                <option value="the-trivia-api">The Trivia API</option>
+                <option value="jservice">JService</option>
+                <option value="manual">ایجاد دستی</option>
+                <option value="community">سازنده‌ها</option>
               </select>
             </div>
             <div>

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "start": "node src/index.js",
     "dev": "node src/index.js",
     "seed:admin": "node src/seed/createAdmin.js",
+    "fix:provider": "node scripts/backfill-jservice-provider.js",
     "test:jservice": "curl -sf http://localhost:4000/api/jservice/random?count=1 | node -e \"const fs=require('fs');function fail(msg){console.error(msg);process.exit(1);}let raw='';try{raw=fs.readFileSync(0,'utf8');}catch(err){fail('Failed to read response');}if(!raw){fail('Empty response');}let payload;try{payload=JSON.parse(raw);}catch(err){fail('Invalid JSON');}const data=Array.isArray(payload?.data)?payload.data:[];if(!data.length){fail('Missing data');}const clue=data[0];if(!Number.isFinite(clue?.id)){fail('Invalid id');}if(typeof clue.question!=='string'||!clue.question.trim()){fail('Invalid question');}if(typeof clue.answer!=='string'||!clue.answer.trim()){fail('Invalid answer');}if(!clue.category||typeof clue.category.title!=='string'||!clue.category.title.trim()){fail('Invalid category.title');}\""
   },
   "dependencies": {

--- a/server/scripts/backfill-jservice-provider.js
+++ b/server/scripts/backfill-jservice-provider.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+const env = require('../src/config/env');
+const Question = require('../src/models/Question');
+
+async function run() {
+  const mongoUri = env.mongo?.uri || process.env.MONGO_URI || 'mongodb://localhost:27017/iquiz';
+  const maxPoolSize = env.mongo?.maxPoolSize || 10;
+
+  await mongoose.connect(mongoUri, {
+    maxPoolSize,
+    serverSelectionTimeoutMS: 10000,
+    socketTimeoutMS: 45000
+  });
+
+  const filter = {
+    $or: [
+      { provider: { $exists: false } },
+      { provider: null },
+      { provider: '' }
+    ],
+    'sourceRef.jserviceId': { $exists: true, $ne: null, $ne: '' }
+  };
+
+  const update = { $set: { provider: 'jservice' } };
+
+  const result = await Question.updateMany(filter, update);
+  const matched = result?.matchedCount ?? result?.n ?? 0;
+  const modified = result?.modifiedCount ?? result?.nModified ?? 0;
+
+  console.log(`Backfill complete. Matched ${matched} document(s), updated ${modified}.`);
+}
+
+run()
+  .catch((error) => {
+    console.error('Failed to backfill JService provider:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try {
+      await mongoose.disconnect();
+    } catch (disconnectError) {
+      console.error('Failed to disconnect from MongoDB cleanly:', disconnectError);
+    }
+  });

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -59,6 +59,7 @@ const jserviceUrl = process.env.JSERVICE_URL || DEFAULT_JSERVICE_URL;
 const jserviceBase = JSERVICE_BASE;
 const port = parseNumber(process.env.PORT, DEFAULT_PORT, { min: 1 });
 const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+const importApprove = parseBoolean(process.env.IMPORT_APPROVE, true);
 
 const env = {
   nodeEnv,
@@ -76,6 +77,9 @@ const env = {
     theTriviaUrl,
     jserviceUrl,
     jserviceBase,
+  },
+  importer: {
+    autoApprove: importApprove
   },
   cors: {
     allowedOrigins

--- a/server/src/models/Question.js
+++ b/server/src/models/Question.js
@@ -43,6 +43,7 @@ const questionSchema = new mongoose.Schema(
     category: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
     categoryName: { type: String, trim: true },
     active: { type: Boolean, default: true },
+    provider: { type: String, trim: true, default: '' },
     source: { type: String, enum: ['manual', 'opentdb', 'the-trivia-api', 'jservice', 'community'], default: 'manual' },
     lang: { type: String, trim: true, default: 'en' },
     type: { type: String, trim: true, default: 'multiple' },


### PR DESCRIPTION
## Summary
- ensure auto-imported questions capture provider metadata, respect IMPORT_APPROVE, and validate MCQ payloads during storage
- add a one-off script plus npm alias to backfill missing JService provider values in existing data
- update questions API and admin panel to expose provider filtering and show JService imports in the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfe57770e48326ab4e277dddd589e9