### PR TITLE
Fix trivia import timestamp conflict

### DIFF
--- a/server/src/services/triviaImporter.js
+++ b/server/src/services/triviaImporter.js
@@ -533,8 +533,6 @@ async function storeNormalizedQuestions(questions, { fetchDurationMs = 0 } = {})
     const isApproved = normalizedStatus === 'approved';
     const active = typeof question.active === 'boolean' ? question.active : isApproved;
     const authorName = sanitizeText(question.authorName) || 'IQuiz Team';
-    const insertedAt = new Date();
-
     operations.push({
       updateOne: {
         filter: { checksum },
@@ -553,9 +551,7 @@ async function storeNormalizedQuestions(questions, { fetchDurationMs = 0 } = {})
             checksum,
             active,
             status: normalizedStatus,
-            authorName,
-            createdAt: insertedAt,
-            updatedAt: insertedAt
+            authorName
           }
         },
         upsert: true


### PR DESCRIPTION
## Summary
- avoid manually setting timestamp fields when upserting trivia questions so Mongoose timestamps do not conflict

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfeb39a2808326910443d79108258b