### PR TITLE
Fix JService question visibility in admin panel

### DIFF
--- a/server/src/services/triviaImporter.js
+++ b/server/src/services/triviaImporter.js
@@ -533,27 +533,34 @@ async function storeNormalizedQuestions(questions, { fetchDurationMs = 0 } = {})
     const isApproved = normalizedStatus === 'approved';
     const active = typeof question.active === 'boolean' ? question.active : isApproved;
     const authorName = sanitizeText(question.authorName) || 'IQuiz Team';
+    const providerForUpdate = normalizedProvider || normalizedSource;
+    const updateDocument = {
+      $setOnInsert: {
+        text,
+        choices: sanitizedChoices,
+        correctIndex: parsedCorrectIndex,
+        difficulty,
+        category: categoryDoc._id,
+        categoryName: categoryDoc.name,
+        provider: providerForUpdate,
+        source: normalizedSource,
+        lang: normalizedLang,
+        type: normalizedType,
+        checksum,
+        active,
+        status: normalizedStatus,
+        authorName
+      }
+    };
+
+    if (providerForUpdate) {
+      updateDocument.$set = { provider: providerForUpdate };
+    }
+
     operations.push({
       updateOne: {
         filter: { checksum },
-        update: {
-          $setOnInsert: {
-            text,
-            choices: sanitizedChoices,
-            correctIndex: parsedCorrectIndex,
-            difficulty,
-            category: categoryDoc._id,
-            categoryName: categoryDoc.name,
-            provider: normalizedProvider,
-            source: normalizedSource,
-            lang: normalizedLang,
-            type: normalizedType,
-            checksum,
-            active,
-            status: normalizedStatus,
-            authorName
-          }
-        },
+        update: updateDocument,
         upsert: true
       }
     });


### PR DESCRIPTION
## Summary
- normalize provider handling in the questions controller so JService filters include legacy records
- extend the provider query to fall back to source metadata when the stored provider value is missing
- ensure the trivia importer keeps the provider field in sync when auto-importing questions

## Testing
- not run (MongoDB/service dependencies are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfed6d19d483268105dc01a2f29f60