### PR TITLE
Improve JService importer and admin filters

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -1761,6 +1761,14 @@
               </select>
             </div>
             <div>
+              <label class="block text-sm mb-1">فیلتر نوع سوال</label>
+              <label class="toggle text-xs">
+                <input type="checkbox" id="filter-type-toggle">
+                <span class="toggle-label">فقط چهارگزینه‌ای</span>
+              </label>
+              <p class="text-[11px] text-white/50 mt-2" id="filter-type-helper">در صورت نیاز می‌توانید سوالات دیگر انواع را نیز نمایش دهید.</p>
+            </div>
+            <div>
               <label class="block text-sm mb-1">جستجو</label>
               <div class="relative">
                 <input id="filter-search" type="search" placeholder="جستجوی سوال..." class="form-input pr-12">
@@ -1785,6 +1793,14 @@
                 <option value="rejected">رد شده</option>
                 <option value="inactive">غیرفعال</option>
               </select>
+            </div>
+            <div>
+              <label class="block text-sm mb-1">فیلتر تایید</label>
+              <label class="toggle text-xs">
+                <input type="checkbox" id="filter-approved-only">
+                <span class="toggle-label">فقط تایید شده</span>
+              </label>
+              <p class="text-[11px] text-white/50 mt-2" id="filter-approved-helper">غیرفعال کردن این گزینه، سوالات تایید نشده را نیز نمایش می‌دهد.</p>
             </div>
           </div>
         </div>

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -61,6 +61,16 @@ const port = parseNumber(process.env.PORT, DEFAULT_PORT, { min: 1 });
 const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
 const importApprove = parseBoolean(process.env.IMPORT_APPROVE, true);
 
+function parseProviderList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(',')
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+const importAutoApproveProviders = parseProviderList(process.env.TRIVIA_AUTO_APPROVE);
+
 const env = {
   nodeEnv,
   isProduction: nodeEnv === 'production',
@@ -79,7 +89,8 @@ const env = {
     jserviceBase,
   },
   importer: {
-    autoApprove: importApprove
+    autoApprove: importApprove,
+    autoApproveProviders: importAutoApproveProviders
   },
   cors: {
     allowedOrigins

--- a/server/src/models/Question.js
+++ b/server/src/models/Question.js
@@ -44,6 +44,7 @@ const questionSchema = new mongoose.Schema(
     categoryName: { type: String, trim: true },
     active: { type: Boolean, default: true },
     provider: { type: String, trim: true, default: '' },
+    providerId: { type: String, trim: true },
     source: { type: String, enum: ['manual', 'opentdb', 'the-trivia-api', 'jservice', 'community'], default: 'manual' },
     lang: { type: String, trim: true, default: 'en' },
     type: { type: String, trim: true, default: 'multiple' },
@@ -52,18 +53,21 @@ const questionSchema = new mongoose.Schema(
       enum: ['pending', 'approved', 'rejected', 'draft', 'archived'],
       default: 'approved'
     },
+    isApproved: { type: Boolean, default: true },
     authorName: { type: String, trim: true, default: 'IQuiz Team' },
     submittedBy: { type: String, trim: true },
     submittedAt: { type: Date },
     reviewedAt: { type: Date },
     reviewedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     reviewNotes: { type: String, trim: true },
-    checksum: { type: String, required: true, trim: true }
+    checksum: { type: String, required: true, trim: true },
+    meta: { type: mongoose.Schema.Types.Mixed, default: {} }
   },
   { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } }
 );
 
 questionSchema.index({ checksum: 1 }, { unique: true, sparse: true });
+questionSchema.index({ provider: 1, providerId: 1 }, { unique: true, sparse: true });
 
 questionSchema.pre('validate', function deriveChecksum(next) {
   if (!this.checksum && this.text && Array.isArray(this.choices) && this.choices.length > 0) {


### PR DESCRIPTION
## Summary
- normalize JService imports into structured multiple-choice questions with provider metadata, auto-approval, and invalid tracking
- tighten the question schema, API filters, and env parsing to support provider/providerId uniqueness and include unapproved toggles
- enhance the admin panel with visible type/approval toggles, richer import reporting, and clearer empty states for JService items

## Testing
- `npm --prefix server run test:jservice` *(fails: Empty response because the API server is not running in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cff0c89d0c8326a34d3c1989024a2f