### PR TITLE
Fix trivia import conflict and remove Cluebase provider

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -1756,8 +1756,6 @@
                 <option value="">همه منابع</option>
                 <option value="opentdb">OpenTDB</option>
                 <option value="the-trivia-api">The Trivia API</option>
-                <option value="cluebase">Cluebase (Jeopardy)</option>
-                <option value="jservice">JService (alias)</option>
                 <option value="manual">ایجاد دستی</option>
                 <option value="community">سازنده‌ها</option>
               </select>

--- a/server/src/services/triviaImporter.js
+++ b/server/src/services/triviaImporter.js
@@ -568,37 +568,30 @@ async function storeNormalizedQuestions(questions, { fetchDurationMs = 0 } = {})
         difficulty,
         category: categoryDoc._id,
         categoryName: categoryDoc.name,
-        provider: providerForUpdate,
         source: normalizedSource,
         lang: normalizedLang,
         type: normalizedType,
         checksum,
-        active,
+        authorName
+      },
+      $set: {
         status: normalizedStatus,
-        authorName,
-        isApproved
+        isApproved,
+        active
       }
     };
 
     if (providerForUpdate) {
-      updateDocument.$set = { provider: providerForUpdate };
-    } else {
-      updateDocument.$set = {};
+      updateDocument.$set.provider = providerForUpdate;
     }
 
     if (providerId) {
-      updateDocument.$setOnInsert.providerId = providerId;
       updateDocument.$set.providerId = providerId;
     }
 
     if (meta) {
-      updateDocument.$setOnInsert.meta = meta;
       updateDocument.$set.meta = meta;
     }
-
-    updateDocument.$set.status = normalizedStatus;
-    updateDocument.$set.isApproved = isApproved;
-    updateDocument.$set.active = active;
 
     operations.push({
       updateOne: {

--- a/server/src/services/triviaProviders.js
+++ b/server/src/services/triviaProviders.js
@@ -27,18 +27,6 @@ const TRIVIA_PROVIDERS = [
       difficulties: { selectable: true, multiple: true },
       breakdown: true
     }
-  },
-  {
-    id: 'cluebase',
-    name: 'Cluebase',
-    shortName: 'Cluebase',
-    description: 'مجموعه‌ای به‌روز از سوالات Jeopardy! با پاسخ‌های ساخت‌یافته و دسته‌بندی‌های متنوع.',
-    capabilities: {
-      amount: { min: 1, max: 50, default: 15 },
-      categories: { selectable: false, remote: false },
-      difficulties: { selectable: false, multiple: false },
-      breakdown: true
-    }
   }
 ];
 
@@ -53,16 +41,7 @@ const PROVIDER_ID_ALIASES = Object.freeze({
   thetriviaapi: 'the-trivia-api',
   'the trivia api': 'the-trivia-api',
   'the-triviaapi': 'the-trivia-api',
-  'the trivia-api': 'the-trivia-api',
-  cluebase: 'cluebase',
-  'clue-base': 'cluebase',
-  'clue_base': 'cluebase',
-  'clue base': 'cluebase',
-  jservice: 'cluebase',
-  'j-service': 'cluebase',
-  'j_service': 'cluebase',
-  'j service': 'cluebase',
-  jeopardy: 'cluebase',
+  'the trivia-api': 'the-trivia-api'
 });
 
 function normalizeProviderId(value) {


### PR DESCRIPTION
## Summary
- limit the admin panel's trivia provider configuration and dropdowns to OpenTDB and The Trivia API only
- streamline provider-related UI logic by removing Cluebase-specific notes and filter handling
- adjust the trivia importer to avoid Mongo update conflicts and trim the backend provider registry to the supported services

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d0368de7dc8326877a9351459a8250