### PR TITLE
Fix static category seeder duplicates

### DIFF
--- a/server/src/services/categorySeeder.js
+++ b/server/src/services/categorySeeder.js
@@ -7,12 +7,17 @@ function sanitizeString(value) {
 }
 
 function buildCategoryDoc(seed) {
-  const name = sanitizeString(seed.displayName || seed.name || seed.slug || 'دسته‌بندی');
-  const displayName = name || 'دسته‌بندی';
+  const name = sanitizeString(seed.name || seed.slug || seed.displayName || 'دسته‌بندی');
+  const displayName = sanitizeString(seed.displayName) || name || 'دسته‌بندی';
   const description = sanitizeString(seed.description);
   const icon = sanitizeString(seed.icon) || 'fa-layer-group';
   const color = sanitizeString(seed.color) || 'blue';
   const provider = sanitizeString(seed.provider) || 'ai-gen';
+  const slug = sanitizeString(seed.slug || seed.id || name).toLowerCase();
+  const providerCategoryIdCandidate = sanitizeString(
+    seed.providerCategoryId || seed.id || seed.slug || ''
+  );
+  const providerCategoryId = providerCategoryIdCandidate || slug;
   const aliases = Array.isArray(seed.aliases)
     ? Array.from(new Set(seed.aliases.map((alias) => sanitizeString(alias)).filter(Boolean)))
     : [];
@@ -27,9 +32,9 @@ function buildCategoryDoc(seed) {
     color,
     status: 'active',
     provider,
-    providerCategoryId: null,
+    providerCategoryId,
     aliases: Array.from(new Set(aliases)),
-    slug: sanitizeString(seed.slug || seed.id || name).toLowerCase()
+    slug
   };
 }
 


### PR DESCRIPTION
## Summary
- ensure seeded categories use the configured English name while preserving localized display names
- assign each seeded category a deterministic providerCategoryId derived from its slug to avoid duplicate key violations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d114d65b088326986cded4485ae3b9