### PR TITLE
Align admin question categories with curated presets

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -4157,25 +4157,29 @@
         <div>
           <label class="block text-sm mb-1">آیکون</label>
           <select class="form-select" data-category-field="icon">
-            <option value="fa-globe">گلوب</option>
-            <option value="fa-map-marked-alt">نقشه</option>
-            <option value="fa-football-ball">توپ فوتبال</option>
-            <option value="fa-flask">فلاسک</option>
-            <option value="fa-landmark">بنای تاریخی</option>
-            <option value="fa-palette">پالت</option>
-            <option value="fa-film">فیلم</option>
+            <option value="fa-earth-asia">دانش عمومی</option>
+            <option value="fa-landmark-dome">میراث تاریخی</option>
+            <option value="fa-mountain-sun">جغرافیا و طبیعت</option>
+            <option value="fa-atom">علوم و فناوری</option>
+            <option value="fa-feather-pointed">ادبیات و زبان</option>
+            <option value="fa-clapperboard">فیلم و سریال</option>
+            <option value="fa-medal">ورزش</option>
+            <option value="fa-gamepad">سرگرمی</option>
+            <option value="fa-layer-group">پیش‌فرض</option>
           </select>
         </div>
         <div>
           <label class="block text-sm mb-1">رنگ</label>
           <select class="form-select" data-category-field="color">
             <option value="blue">آبی</option>
-            <option value="green">سبز</option>
             <option value="orange">نارنجی</option>
+            <option value="teal">فیروزه‌ای</option>
+            <option value="indigo">نیلی</option>
             <option value="purple">بنفش</option>
             <option value="yellow">زرد</option>
             <option value="pink">صورتی</option>
             <option value="red">قرمز</option>
+            <option value="green">سبز</option>
           </select>
         </div>
         <div class="flex gap-3">

--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -1044,6 +1044,9 @@ function sanitizeCategoryList(list) {
         ? Number(category.inactiveQuestionCount)
         : Math.max(totalQuestions - activeQuestions, 0);
       const inactiveQuestions = Math.max(inactiveQuestionsRaw, 0);
+      const order = Number.isFinite(Number(category.order))
+        ? Number(category.order)
+        : 0;
       return {
         ...category,
         _id: String(category._id),
@@ -1056,10 +1059,17 @@ function sanitizeCategoryList(list) {
         status: category.status || 'active',
         questionCount: totalQuestions,
         activeQuestionCount: activeQuestions,
-        inactiveQuestionCount: inactiveQuestions
+        inactiveQuestionCount: inactiveQuestions,
+        order
       };
     })
-    .filter(Boolean);
+    .filter(Boolean)
+    .sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      const aLabel = a.displayName || a.name || '';
+      const bLabel = b.displayName || b.name || '';
+      return aLabel.localeCompare(bLabel, 'fa');
+    });
 }
 
 function categoryOptionLabel(category) {

--- a/server/src/config/categories.js
+++ b/server/src/config/categories.js
@@ -1,7 +1,8 @@
-const CATEGORIES = [
+const CATEGORY_DEFINITIONS = Object.freeze([
   {
+    order: 1,
     slug: 'general',
-    name: 'General',
+    name: 'General Knowledge',
     displayName: 'عمومی',
     description: 'سوالاتی متنوع از دانستنی‌های روزمره و موضوعات عمومی.',
     icon: 'fa-earth-asia',
@@ -9,6 +10,7 @@ const CATEGORIES = [
     aliases: ['عمومی', 'دانش عمومی', 'General']
   },
   {
+    order: 2,
     slug: 'history-civilization',
     name: 'History & Civilization',
     displayName: 'تاریخ و تمدن',
@@ -18,6 +20,7 @@ const CATEGORIES = [
     aliases: ['تاریخ', 'تمدن', 'History']
   },
   {
+    order: 3,
     slug: 'geography-nature',
     name: 'Geography & Nature',
     displayName: 'جغرافیا و طبیعت',
@@ -27,6 +30,7 @@ const CATEGORIES = [
     aliases: ['جغرافیا', 'طبیعت', 'Geography']
   },
   {
+    order: 4,
     slug: 'science-technology',
     name: 'Science & Technology',
     displayName: 'علوم و فناوری',
@@ -36,6 +40,7 @@ const CATEGORIES = [
     aliases: ['علم', 'فناوری', 'Science']
   },
   {
+    order: 5,
     slug: 'literature-language',
     name: 'Literature & Language',
     displayName: 'ادبیات و زبان',
@@ -45,6 +50,7 @@ const CATEGORIES = [
     aliases: ['ادبیات', 'زبان', 'Literature']
   },
   {
+    order: 6,
     slug: 'movies-series',
     name: 'Movies & Series',
     displayName: 'فیلم و سریال',
@@ -54,6 +60,7 @@ const CATEGORIES = [
     aliases: ['فیلم', 'سریال', 'Movies']
   },
   {
+    order: 7,
     slug: 'sports',
     name: 'Sports',
     displayName: 'ورزش',
@@ -63,6 +70,7 @@ const CATEGORIES = [
     aliases: ['ورزش', 'Sport', 'Sports']
   },
   {
+    order: 8,
     slug: 'entertainment',
     name: 'Entertainment',
     displayName: 'سرگرمی',
@@ -71,6 +79,51 @@ const CATEGORIES = [
     color: 'pink',
     aliases: ['سرگرمی', 'تفریح', 'Entertainment']
   }
-];
+]);
 
-module.exports = { CATEGORIES };
+const CATEGORIES = Object.freeze(
+  CATEGORY_DEFINITIONS.map((category) => {
+    const order = Number.isFinite(Number(category.order)) ? Number(category.order) : 0;
+    const slug = String(category.slug || '').trim();
+    const name = category.name || category.displayName || slug || 'Category';
+    const displayName = category.displayName || name;
+    const description = category.description || '';
+    const icon = category.icon || 'fa-layer-group';
+    const color = category.color || 'blue';
+    const provider = category.provider || 'ai-gen';
+    const providerCategoryId = category.providerCategoryId || slug;
+    const aliases = Array.isArray(category.aliases)
+      ? category.aliases
+      : [];
+
+    const normalizedAliases = Array.from(
+      new Set(
+        [...aliases, displayName, name]
+          .map((alias) => String(alias ?? '').trim())
+          .filter((alias) => alias.length > 0)
+      )
+    );
+
+    return Object.freeze({
+      order,
+      slug,
+      name,
+      displayName,
+      description,
+      icon,
+      color,
+      aliases: normalizedAliases,
+      provider,
+      providerCategoryId
+    });
+  })
+);
+
+const CATEGORY_LOOKUP_BY_SLUG = Object.freeze(
+  CATEGORIES.reduce((acc, category) => {
+    acc[category.slug] = category;
+    return acc;
+  }, {})
+);
+
+module.exports = { CATEGORIES, CATEGORY_LOOKUP_BY_SLUG };

--- a/server/src/controllers/categories.controller.js
+++ b/server/src/controllers/categories.controller.js
@@ -93,7 +93,11 @@ exports.list = async (req, res, next) => {
     const skip = (pageNumber - 1) * limitNumber;
 
     const [itemsRaw, total] = await Promise.all([
-      Category.find(where).sort({ createdAt: -1 }).skip(skip).limit(limitNumber).lean(),
+      Category.find(where)
+        .sort({ order: 1, createdAt: -1 })
+        .skip(skip)
+        .limit(limitNumber)
+        .lean(),
       Category.countDocuments(where)
     ]);
 

--- a/server/src/models/Category.js
+++ b/server/src/models/Category.js
@@ -46,6 +46,11 @@ const categorySchema = new mongoose.Schema(
       type: [String],
       default: [],
       set: sanitizeAliases
+    },
+    order: {
+      type: Number,
+      default: 0,
+      min: 0
     }
   },
   { timestamps: true }
@@ -53,6 +58,7 @@ const categorySchema = new mongoose.Schema(
 
 categorySchema.index({ provider: 1, providerCategoryId: 1 }, { unique: true, sparse: true });
 categorySchema.index({ slug: 1 }, { unique: true });
+categorySchema.index({ order: 1, createdAt: -1 });
 
 categorySchema.pre('validate', async function ensureSlug(next) {
   try {

--- a/server/src/services/categorySeeder.js
+++ b/server/src/services/categorySeeder.js
@@ -18,6 +18,7 @@ function buildCategoryDoc(seed) {
     seed.providerCategoryId || seed.id || seed.slug || ''
   );
   const providerCategoryId = providerCategoryIdCandidate || slug;
+  const order = Number.isFinite(Number(seed.order)) ? Number(seed.order) : 0;
   const aliases = Array.isArray(seed.aliases)
     ? Array.from(new Set(seed.aliases.map((alias) => sanitizeString(alias)).filter(Boolean)))
     : [];
@@ -34,7 +35,8 @@ function buildCategoryDoc(seed) {
     provider,
     providerCategoryId,
     aliases: Array.from(new Set(aliases)),
-    slug
+    slug,
+    order
   };
 }
 
@@ -67,7 +69,8 @@ async function seedStaticCategories() {
             provider: doc.provider,
             providerCategoryId: doc.providerCategoryId,
             aliases: doc.aliases,
-            slug: doc.slug
+            slug: doc.slug,
+            order: doc.order
           }
         },
         {

--- a/server/src/services/publicContent.js
+++ b/server/src/services/publicContent.js
@@ -1,67 +1,34 @@
+const { CATEGORIES } = require('../config/categories');
+
 const DEFAULT_DIFFICULTIES = [
   { value: 'easy', label: 'آسان' },
   { value: 'medium', label: 'متوسط' },
   { value: 'hard', label: 'سخت' }
 ];
 
-const FALLBACK_CATEGORY_DATA = [
-  {
-    id: 'general',
-    title: 'عمومی',
-    description: 'پرسش‌های متنوع از دانستنی‌های روزمره و موضوعات عمومی.',
-    icon: 'fa-earth-asia',
-    color: '#60a5fa'
-  },
-  {
-    id: 'history-civilization',
-    title: 'تاریخ و تمدن',
-    description: 'رویدادها، شخصیت‌ها و میراث فرهنگی ایران و جهان.',
-    icon: 'fa-landmark-dome',
-    color: '#f97316'
-  },
-  {
-    id: 'geography-nature',
-    title: 'جغرافیا و طبیعت',
-    description: 'اقلیم‌ها، سرزمین‌ها و شگفتی‌های طبیعی دنیا.',
-    icon: 'fa-mountain-sun',
-    color: '#14b8a6'
-  },
-  {
-    id: 'science-technology',
-    title: 'علوم و فناوری',
-    description: 'دانسته‌های علمی، کشفیات تازه و نوآوری‌های فناوری.',
-    icon: 'fa-atom',
-    color: '#6366f1'
-  },
-  {
-    id: 'literature-language',
-    title: 'ادبیات و زبان',
-    description: 'شاهکارهای ادبی، زبان‌ها و ظرافت‌های واژگانی.',
-    icon: 'fa-feather-pointed',
-    color: '#a855f7'
-  },
-  {
-    id: 'movies-series',
-    title: 'فیلم و سریال',
-    description: 'دنیای سینما، تلویزیون و شخصیت‌های ماندگار داستانی.',
-    icon: 'fa-clapperboard',
-    color: '#facc15'
-  },
-  {
-    id: 'sports',
-    title: 'ورزش',
-    description: 'مسابقات، رکوردها و قهرمانان محبوب ورزشی.',
-    icon: 'fa-medal',
-    color: '#f87171'
-  },
-  {
-    id: 'entertainment',
-    title: 'سرگرمی',
-    description: 'بازی‌ها، پازل‌ها و فعالیت‌های سرگرم‌کننده برای اوقات فراغت.',
-    icon: 'fa-gamepad',
-    color: '#f472b6'
-  }
-];
+const CATEGORY_COLOR_HEX = {
+  blue: '#60a5fa',
+  orange: '#f97316',
+  teal: '#14b8a6',
+  indigo: '#6366f1',
+  purple: '#a855f7',
+  yellow: '#facc15',
+  red: '#f87171',
+  pink: '#f472b6'
+};
+
+const FALLBACK_CATEGORY_DATA = Array.from(CATEGORIES)
+  .sort((a, b) => {
+    if (a.order !== b.order) return a.order - b.order;
+    return (a.displayName || a.name || '').localeCompare(b.displayName || b.name || '', 'fa');
+  })
+  .map((category) => ({
+    id: category.slug,
+    title: category.displayName || category.name,
+    description: category.description || '',
+    icon: category.icon || 'fa-layer-group',
+    color: CATEGORY_COLOR_HEX[category.color] || CATEGORY_COLOR_HEX.blue
+  }));
 
 const FALLBACK_PROVINCES = [
   'آذربایجان شرقی',


### PR DESCRIPTION
## Summary
- centralize the curated eight admin question categories with ordering, metadata and slug aliases
- persist the category order field through the schema, seeder and list controller while reusing the shared config for public fallbacks
- refresh the admin UI icon and color selectors plus client-side sorting so the management filters reflect the new lineup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d11d5e67f48326ae928a6d8d6aaca2