### PR TITLE
Fix category seeder to avoid duplicate name errors

### DIFF
--- a/server/src/services/categorySeeder.js
+++ b/server/src/services/categorySeeder.js
@@ -55,9 +55,17 @@ async function seedStaticCategories() {
     allowedSlugs.add(doc.slug);
 
     try {
+      const query = {
+        $or: [{ slug: doc.slug }, { name: doc.name }]
+      };
+
+      if (doc.providerCategoryId) {
+        query.$or.push({ provider: doc.provider, providerCategoryId: doc.providerCategoryId });
+      }
+
       // eslint-disable-next-line no-await-in-loop
       const result = await Category.updateOne(
-        { slug: doc.slug },
+        query,
         {
           $set: {
             name: doc.name,


### PR DESCRIPTION
## Summary
- update the static category seeder to reuse existing categories by slug, name, or provider identifier before upserting

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1208676a4832682340d2251655e0a