### PR TITLE
Remove Jeopardy quick quiz feature from bot UI

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1447,18 +1447,6 @@
         </div>
       </div>
     </section>
-    <section id="page-jservice-demo" class="space-y-4">
-      <div class="glass rounded-3xl border border-white/10 p-6 shadow-xl space-y-4">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <h2 class="text-xl font-extrabold">سوالات سریع جئوپاردی</h2>
-            <p class="text-sm text-white/70 mt-1">سوال‌های تصادفی با گزینه‌های چهارگانه</p>
-          </div>
-          <span class="px-3 py-1 rounded-full bg-white/10 border border-white/20 text-xs text-white/80">JService</span>
-        </div>
-        <div id="quiz-root" class="space-y-4 text-sm text-white/70" aria-live="polite"></div>
-      </div>
-    </section>
   </main>
   
   <!-- Bottom Nav -->
@@ -1801,7 +1789,6 @@
   <!-- Confetti -->
   <canvas id="confetti" class="confetti"></canvas>
   
-<script type="module" src="public/js/jservice.js"></script>
 <script type="module" src="./Iquiz-assets/main.js" defer></script>
 
 </body>


### PR DESCRIPTION
## Summary
- remove the Jeopardy quick question section from the bot interface
- drop the unused jService script reference from the page markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d13417203c8326aec39418d282f398