### PR TITLE
Add quit confirmation modal before leaving quiz

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1613,6 +1613,40 @@
     </div>
   </div>
 
+  <!-- Quit Confirmation Modal -->
+  <div id="modal-quit-confirm" class="modal" role="dialog" aria-modal="true" aria-labelledby="quit-confirm-title" aria-describedby="quit-confirm-message">
+    <div class="glass rounded-3xl p-6 w-full max-w-sm space-y-5 text-center">
+      <div class="flex justify-center">
+        <div class="w-16 h-16 rounded-2xl bg-rose-500/15 border border-rose-400/40 text-rose-200 flex items-center justify-center text-2xl shadow-inner">
+          <i class="fas fa-circle-question"></i>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <h3 id="quit-confirm-title" class="text-xl font-extrabold">خروج از مسابقه؟</h3>
+        <p id="quit-confirm-message" class="text-sm opacity-80 leading-6">آیا مطمئن هستید که می‌خواهید مسابقه را ترک کنید؟ نتیجهٔ سؤالات پاسخ‌داده‌شده ثبت می‌شود.</p>
+      </div>
+      <p id="quit-summary-text" class="text-sm opacity-80 leading-6"></p>
+      <div id="quit-progress" class="grid gap-2 text-sm">
+        <div class="glass-dark rounded-2xl px-4 py-3 flex items-center justify-between">
+          <span class="flex items-center gap-2"><i class="fas fa-list-check text-sky-300"></i><span>سؤالات پاسخ‌داده‌شده</span></span>
+          <span id="quit-answered-count" class="font-bold">۰</span>
+        </div>
+        <div class="glass-dark rounded-2xl px-4 py-3 flex items-center justify-between">
+          <span class="flex items-center gap-2"><i class="fas fa-check text-emerald-300"></i><span>پاسخ‌های درست</span></span>
+          <span id="quit-correct-count" class="font-bold">۰</span>
+        </div>
+        <div class="glass-dark rounded-2xl px-4 py-3 flex items-center justify-between">
+          <span class="flex items-center gap-2"><i class="fas fa-star text-yellow-300"></i><span>امتیاز فعلی</span></span>
+          <span id="quit-earned-score" class="font-bold">۰</span>
+        </div>
+      </div>
+      <div class="grid gap-3">
+        <button type="button" id="confirm-quit" class="btn btn-primary w-full"><i class="fas fa-door-open ml-2"></i> خروج و نمایش نتیجه</button>
+        <button type="button" id="btn-continue-quiz" class="w-full py-3 rounded-2xl bg-white/10 border border-white/20 hover:bg-white/20 transition">ادامه مسابقه</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Province Select Modal -->
   <div id="modal-province-select" class="modal">
     <div class="glass rounded-3xl p-5 w-full max-w-md text-center">


### PR DESCRIPTION
## Summary
- add a confirmation modal to quit the quiz that highlights answered questions, correct answers, and earned points
- pause and resume the quiz timer around the confirmation flow and finalize the quiz with results when exiting

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d13a68a9088326b4c7ef536f837101