### PR TITLE
Fix timer reset redeclaration

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -1540,6 +1540,7 @@ function resetTimer(seconds){
   State.quiz.remain   = effective;
 
   updateTimerVisual?.();
+  startQuizTimerCountdown();
 }
 
 function startQuizTimerCountdown(){
@@ -1570,16 +1571,6 @@ function startQuizTimerCountdown(){
     }
   }, 1000);
 }
-
-
-  function resetTimer(seconds){
-    const ring = $('#timer-ring');
-    if(ring) ring.setAttribute('stroke-dasharray', String(TIMER_CIRC));
-    State.quiz.duration = seconds;
-    State.quiz.remain = seconds;
-    updateTimerVisual();
-    startQuizTimerCountdown();
-  }
 
   function addExtraTime(extra){
     if(!Number.isFinite(extra) || extra <= 0) return;


### PR DESCRIPTION
## Summary
- consolidate the quiz resetTimer logic into a single implementation
- ensure resetting the timer also restarts the countdown to avoid stale intervals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d149144aec8326a0552d3825586db6