### PR TITLE
Update group battle UI after simulation

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -4775,6 +4775,10 @@ function renderGroupBattleCard(list, userGroup) {
 
     saveState();
 
+    renderHeader();
+    renderDashboard();
+    updateLimitsUI();
+
     startBtn.disabled = false;
     startBtn.innerHTML = originalLabel;
 


### PR DESCRIPTION
## Summary
- refresh header, dashboard, and limits UI after saving state in the group battle card
- ensure existing top bar and battle view refresh logic runs after the new updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1608687688326a1af058f2b9a78ac