### PR TITLE
Improve match type layout on very small screens

### DIFF
--- a/Iquiz-assets/style.css
+++ b/Iquiz-assets/style.css
@@ -446,6 +446,15 @@
       .duel-add-card .btn{ width:100%; }
     }
 
+    @media(max-width:360px){
+      .match-types{ grid-template-columns:repeat(2,minmax(0,1fr)); }
+      .match-type-card{ padding:1.2rem; }
+    }
+
+    @media(max-width:320px){
+      .match-types{ grid-template-columns:1fr; }
+    }
+
     @media(min-width:641px) and (max-width:1024px){
       .match-types{ grid-template-columns:repeat(2,1fr); }
     }


### PR DESCRIPTION
## Summary
- add a narrow-screen media query so match type cards switch to a two-column grid at ≤360px
- increase the padding of match type cards in that viewport range for better touch targets
- ensure ultra-small (≤320px) screens fall back to a single column layout

## Testing
- Manually checked match type grid at 360px and 320px using Playwright screenshots


------
https://chatgpt.com/codex/tasks/task_e_68d1720cc4088326800b3eca6719cd91