### PR TITLE
Guard duel cancel handler against missing session

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -3305,8 +3305,10 @@ async function startPurchaseCoins(pkgId){
         <button id="duel-cancel" class="btn btn-secondary w-full mt-4"><i class="fas fa-times ml-2"></i> انصراف</button>
       `);
       $('#duel-cancel')?.addEventListener('click', () => {
-        DuelSession.awaitingSelection = false;
-        cancelDuelSession('user_cancelled');
+        if (DuelSession) {
+          DuelSession.awaitingSelection = false;
+          cancelDuelSession('user_cancelled');
+        }
         closeDetailPopup({ skipDuelCancel: true });
       });
       $$('#detail-content .duel-category-option').forEach(btn => {


### PR DESCRIPTION
## Summary
- guard the duel cancel button handler so it skips session updates when no duel is active
- still close the detail popup after the handler runs to avoid leaving the UI open

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d17d6f6aa08326893faa3964811e39