### PR TITLE
Fix OpenAI Responses API format parameter

### DIFF
--- a/server/src/services/aiQuestionGenerator.js
+++ b/server/src/services/aiQuestionGenerator.js
@@ -117,7 +117,9 @@ async function callOpenAi({ topic, count, difficulty, lang, model }) {
     frequency_penalty: 0.6,
     presence_penalty: 0.2,
     max_output_tokens: Math.min(120 * count, 120 * MAX_COUNT),
-    response_format: buildResponseFormat(count)
+    text: {
+      format: buildResponseFormat(count)
+    }
   };
 
   const headers = {


### PR DESCRIPTION
## Summary
- update the OpenAI payload to use `text.format` for the JSON schema configuration when requesting generated questions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a30669e88326bfd6bd0896c17a06