### PR TITLE
Remove unsupported penalties from OpenAI responses payload

### DIFF
--- a/server/src/services/aiQuestionGenerator.js
+++ b/server/src/services/aiQuestionGenerator.js
@@ -114,8 +114,6 @@ async function callOpenAi({ topic, count, difficulty, lang, model }) {
     ],
     temperature: 0.4,
     top_p: 0.9,
-    frequency_penalty: 0.6,
-    presence_penalty: 0.2,
     max_output_tokens: Math.min(120 * count, 120 * MAX_COUNT),
     text: {
       format: buildResponseFormat(count)


### PR DESCRIPTION
## Summary
- remove deprecated frequency_penalty and presence_penalty fields from the Responses API payload so only supported options are sent

## Testing
- not run (requires OpenAI API key)


------
https://chatgpt.com/codex/tasks/task_e_68d1a491940c8326950db041ba09fcff