### PR TITLE
Update AI generation endpoint path in admin panel

### DIFF
--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -1157,7 +1157,7 @@ async function runAiGeneration(previewOnly = false) {
   setAiStatus(previewOnly ? 'در حال آماده‌سازی پیش‌نمایش...' : 'در حال تولید سوالات...', 'info');
 
   try {
-    const response = await api('/ai/generate-questions', {
+    const response = await api('/ai/generate', {
       method: 'POST',
       body: JSON.stringify(body)
     });

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -13,5 +13,6 @@ const aiLimiter = rateLimit({
 
 router.use(protect, adminOnly);
 router.post('/generate', aiLimiter, aiController.generate);
+router.post('/generate-questions', aiLimiter, aiController.generate);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- update the admin panel AI generation call to use the `/ai/generate` endpoint
- add a compatibility alias for the legacy `/ai/generate-questions` route on the backend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a7363f348326b7e18a9966d25d33