### PR TITLE
Fix AI preview to use Responses API and render Persian MCQs

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -2484,7 +2484,7 @@
             </div>
             <div class="ai-preview-pane" id="ai-preview-pane-unique" data-mode="unique" role="tabpanel" aria-labelledby="ai-preview-tab-unique">
               <div class="ai-preview-table-wrapper" tabindex="0">
-                <table class="ai-preview-table">
+                <table class="ai-preview-table" dir="rtl">
                   <thead>
                     <tr>
                       <th scope="col">سوال</th>
@@ -2502,7 +2502,7 @@
             </div>
             <div class="ai-preview-pane hidden" id="ai-preview-pane-duplicates" data-mode="duplicates" role="tabpanel" aria-labelledby="ai-preview-tab-duplicates" aria-hidden="true">
               <div class="ai-preview-table-wrapper" tabindex="0">
-                <table class="ai-preview-table ai-preview-table-compact ai-preview-table-duplicates">
+                <table class="ai-preview-table ai-preview-table-compact ai-preview-table-duplicates" dir="rtl">
                   <thead>
                     <tr>
                       <th scope="col">سوال</th>
@@ -2519,7 +2519,7 @@
             </div>
             <div class="ai-preview-pane hidden" id="ai-preview-pane-invalid" data-mode="invalid" role="tabpanel" aria-labelledby="ai-preview-tab-invalid" aria-hidden="true">
               <div class="ai-preview-table-wrapper" tabindex="0">
-                <table class="ai-preview-table ai-preview-table-compact ai-preview-table-invalid">
+                <table class="ai-preview-table ai-preview-table-compact ai-preview-table-invalid" dir="rtl">
                   <thead>
                     <tr>
                       <th scope="col">سوال</th>
@@ -4113,7 +4113,7 @@
               پیش‌نمایش سوالات تولیدی
             </h4>
             <div class="overflow-x-auto rounded-xl border border-white/10">
-              <table class="ai-modal-preview-table">
+              <table class="ai-modal-preview-table" dir="rtl">
                 <thead>
                   <tr>
                     <th scope="col">متن سوال</th>

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "mongoose": "^7.6.3",
     "morgan": "^1.10.1",
     "node-fetch": "^2.6.7",
+    "openai": "^4.58.1",
     "validator": "^13.11.0",
     "winston": "^3.13.0",
     "xss-clean": "^0.1.4"

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -5,7 +5,7 @@ const DEFAULT_NODE_ENV = 'development';
 const DEFAULT_MONGO_URI = 'mongodb://localhost:27017/iquiz';
 const DEFAULT_MONGO_MAX_POOL = 10;
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
+const DEFAULT_OPENAI_MODEL = 'gpt-5';
 
 const truthyValues = new Set(['true', '1', 'yes', 'y', 'on']);
 const falsyValues = new Set(['false', '0', 'no', 'n', 'off']);


### PR DESCRIPTION
## Summary
- switch the AI question generator over to the OpenAI Responses API with the new json_schema contract and expose a generateMCQs helper
- normalize returned preview, duplicate, and invalid items so the admin preview tables render Persian prompts and answers correctly and mark preview tables as RTL
- set the default OpenAI model to gpt-5 and declare the OpenAI SDK dependency for the server

## Testing
- not run (registry access for `npm install` to fetch the OpenAI SDK is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d38fd582d08326ae308f374c891e20