### PR TITLE
Fix OpenAI request payload for question preview

### DIFF
--- a/server/src/services/aiQuestionGenerator.js
+++ b/server/src/services/aiQuestionGenerator.js
@@ -102,13 +102,13 @@ async function callOpenAi({ topic, count, difficulty, lang, model }) {
       {
         role: 'system',
         content: [
-          { type: 'text', text: 'You create high-quality multiple choice questions for quizzes.' }
+          { type: 'input_text', text: 'You create high-quality multiple choice questions for quizzes.' }
         ]
       },
       {
         role: 'user',
         content: [
-          { type: 'text', text: prompt }
+          { type: 'input_text', text: prompt }
         ]
       }
     ],


### PR DESCRIPTION
## Summary
- update the OpenAI Responses payload to use input_text content blocks for system and user prompts

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d39cf531f88326a9e35aa176802540