### PR TITLE
Fix AI generation handler to use OpenAI responses API

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "morgan": "^1.10.1",
+        "openai": "^4.56.0",
         "validator": "^13.11.0",
         "winston": "^3.13.0",
         "xss-clean": "^0.1.4"

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
     "morgan": "^1.10.1",
+    "openai": "^4.56.0",
     "node-fetch": "^2.6.7",
     "validator": "^13.11.0",
     "winston": "^3.13.0",


### PR DESCRIPTION
## Summary
- switch the AI question generator to the official `openai` SDK and send requests with the new `responses.create` JSON-schema format
- harden response parsing/normalisation and surface optional explanations in previews and saved metadata
- declare the `openai` runtime dependency so the service can initialise the client

## Testing
- `npm ci --ignore-scripts --legacy-peer-deps` *(fails: registry returned HTTP 403 while downloading openai)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c30b62e48326b293116a6de10b99