### PR TITLE
Update AI Responses API payload format

### DIFF
--- a/server/src/services/aiQuestionGenerator.js
+++ b/server/src/services/aiQuestionGenerator.js
@@ -7,7 +7,14 @@ async function generateQuestions({ systemPrompt, userPrompt, schema, temperature
       { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
       { role: 'user',   content: [{ type: 'input_text', text: userPrompt   }] }
     ],
-    response_format: { type: 'json_schema', json_schema: { name: 'mcq_batch', schema, strict: true } },
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'mcq_batch',
+        schema,
+        strict: true
+      }
+    },
     temperature
   };
 


### PR DESCRIPTION
## Summary
- migrate the AI question generator payload to the new Responses API `text.format` JSON schema shape with the required name field

## Testing
- ⚠️ `OPENAI_API_KEY=test MONGO_URI=mongodb://127.0.0.1:27017/iquiz npm start` *(fails: MongoDB is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d49f86ec832698ccc0ae21122843