### PR TITLE
Fix manual questions not appearing in admin and bot

### DIFF
--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -554,7 +554,7 @@ const shopShowTutorialToggle = $('#shop-show-tutorial');
 const questionFilters = {
   category: '',
   difficulty: '',
-  provider: 'ai-gen',
+  provider: '',
   status: '',
   search: '',
   sort: 'newest',
@@ -4330,7 +4330,6 @@ async function loadQuestions(overrides = {}) {
       tbody.onclick = null;
     }
 
-    questionFilters.provider = 'ai-gen';
     const params = new URLSearchParams({ limit: '50' });
     if (questionFilters.category) params.append('category', questionFilters.category);
     if (questionFilters.difficulty) params.append('difficulty', questionFilters.difficulty);
@@ -4374,7 +4373,7 @@ async function loadQuestions(overrides = {}) {
       );
       let emptyMessage;
       if (questionFilters.category) {
-        emptyMessage = 'برای این دسته هنوز سوال AI ثبت نشده.';
+        emptyMessage = 'برای این دسته هنوز سوالی ثبت نشده است.';
       } else if (questionFilters.duplicates === 'duplicates') {
         emptyMessage = 'هیچ سوال تکراری با تنظیمات فعلی یافت نشد.';
       } else if (hasFilters) {

--- a/server/src/controllers/questions.controller.js
+++ b/server/src/controllers/questions.controller.js
@@ -156,7 +156,8 @@ exports.create = async (req, res, next) => {
       correctIndex: idx,
       difficulty: safeDifficulty,
       category: category._id,
-      categoryName: category.name,
+      categoryName: category.displayName || category.name,
+      categorySlug: deriveCategorySlug(category),
       active: isActive,
       lang: detectedLang,
       source: safeSource,
@@ -245,10 +246,6 @@ exports.list = async (req, res, next) => {
 
       if (!where.$and) where.$and = [];
       where.$and.push({ $or: providerConditions });
-    }
-
-    if (!providerCandidate) {
-      where.provider = 'ai-gen';
     }
 
     if (status) {


### PR DESCRIPTION
## Summary
- stop forcing the question list to filter by the AI provider so newly created manual questions are returned
- persist friendlier category metadata (display name and slug) when saving a question so downstream consumers have consistent data

## Testing
- not run (MongoDB instance is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3fab7c3c483268e10e292f2dbb6a7