### PR TITLE
Enhance import questions modal action buttons

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -1315,6 +1315,76 @@
       font-size: 0.9rem;
     }
 
+    #import-questions-modal .modal-actions {
+      padding: 1.6rem 1.85rem 1.9rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.9rem;
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.8) 100%);
+    }
+
+    #import-questions-modal .modal-actions .btn {
+      flex: 1 1 230px;
+      width: auto;
+      min-height: 3.2rem;
+      border-radius: 999px;
+      font-size: 1rem;
+      letter-spacing: -0.01em;
+      position: relative;
+      overflow: hidden;
+    }
+
+    #import-questions-modal .modal-actions .btn::after {
+      content: "";
+      position: absolute;
+      inset: -30% auto -30% 65%;
+      width: 45%;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.55), transparent 70%);
+      opacity: 0;
+      transform: translate3d(0, 0, 0) rotate(12deg);
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+    }
+
+    #import-questions-modal .modal-actions .btn:hover::after {
+      opacity: 0.5;
+    }
+
+    #import-questions-submit {
+      background: linear-gradient(135deg, rgba(253, 224, 71, 0.95), rgba(251, 146, 60, 0.9), rgba(236, 72, 153, 0.92));
+      color: #0f172a;
+      border: 1px solid rgba(251, 191, 36, 0.55);
+      box-shadow: 0 22px 45px -18px rgba(251, 191, 36, 0.7);
+    }
+
+    #import-questions-submit:hover {
+      box-shadow: 0 30px 60px -22px rgba(251, 191, 36, 0.75);
+    }
+
+    #import-questions-modal .modal-actions .btn-secondary {
+      background: linear-gradient(135deg, rgba(148, 163, 184, 0.22), rgba(148, 163, 184, 0.12));
+      color: #f8fafc;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      box-shadow: 0 18px 40px -20px rgba(15, 23, 42, 0.85);
+    }
+
+    #import-questions-modal .modal-actions .btn-secondary:hover {
+      background: linear-gradient(135deg, rgba(148, 163, 184, 0.32), rgba(148, 163, 184, 0.18));
+      border-color: rgba(226, 232, 240, 0.45);
+      color: #fff;
+    }
+
+    @media (max-width: 640px) {
+      #import-questions-modal .modal-actions {
+        flex-direction: column;
+      }
+
+      #import-questions-modal .modal-actions .btn {
+        width: 100%;
+      }
+    }
+
     /* Responsive adjustments */
     @media (max-width: 768px) {
       body {
@@ -3884,9 +3954,13 @@
       </div>
       <div class="modal-actions safe">
         <button type="button" id="import-questions-submit" class="btn btn-primary">
-          ثبت سوالات انتخاب شده
+          <i class="fa-solid fa-check-double text-lg"></i>
+          <span class="font-extrabold text-base md:text-lg">ثبت سوالات انتخاب شده</span>
         </button>
-        <button type="button" class="btn btn-secondary close-modal">بستن</button>
+        <button type="button" class="btn btn-secondary close-modal">
+          <i class="fa-solid fa-circle-xmark text-lg"></i>
+          <span class="font-semibold text-base md:text-lg">بستن</span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- restyle the import questions modal action area with a richer gradient background and pill-shaped controls
- add hover lighting effects and dedicated styling for the submit and close buttons to improve hierarchy
- include contextual icons alongside the button labels for a more polished experience

## Testing
- Not Run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d44e8153bc8326ade76954d69e95a0