### PR TITLE
Add fallback quiz questions for every category

### DIFF
--- a/server/src/services/publicContent.js
+++ b/server/src/services/publicContent.js
@@ -75,7 +75,296 @@ const FALLBACK_PROVINCES = [
   'یزد'
 ].map(name => ({ name, score: 0, members: 0 }));
 
-const FALLBACK_QUESTION_DATA = Object.freeze([]);
+function buildFallbackQuestion({
+  id,
+  slug,
+  text,
+  difficulty = 'medium',
+  options = [],
+  correctIdx = 0
+}) {
+  const category = FALLBACK_CATEGORY_DATA.find((cat) => cat.slug === slug) || {
+    id: slug,
+    title: '—'
+  };
+
+  const safeOptions = options.map((option) => String(option || '').trim()).filter(Boolean);
+
+  return Object.freeze({
+    id,
+    publicId: id,
+    categoryId: category.id,
+    categorySlug: slug,
+    categoryName: category.title,
+    cat: category.title,
+    difficulty,
+    text,
+    title: text,
+    options: safeOptions,
+    choices: safeOptions,
+    correctIdx,
+    answerIndex: correctIdx
+  });
+}
+
+const FALLBACK_QUESTION_DATA = Object.freeze([
+  buildFallbackQuestion({
+    id: 'general-1',
+    slug: 'general',
+    difficulty: 'easy',
+    text: 'کدام گزینه به معنی «دانش جمعی انسان‌ها درباره جهان» نزدیک‌تر است؟',
+    options: ['علم', 'فرهنگ', 'تجربه', 'هنر'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'general-2',
+    slug: 'general',
+    difficulty: 'medium',
+    text: 'کدام یک از موارد زیر نمادی برای المپیک است؟',
+    options: ['پنج حلقه رنگی', 'یک مشعل آتشین', 'دو شمشیر ضربدری', 'یک ستاره پنج پر'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'general-3',
+    slug: 'general',
+    difficulty: 'medium',
+    text: 'تقویم میلادی بر اساس حرکت کدام جرم سماوی تنظیم شده است؟',
+    options: ['ماه', 'زمین', 'خورشید', 'زهره'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'general-4',
+    slug: 'general',
+    difficulty: 'hard',
+    text: 'اصطلاح «جهان‌بینی» بیشتر به چه حوزه‌ای مربوط می‌شود؟',
+    options: ['فلسفه', 'جغرافیا', 'ورزش', 'ریاضیات'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'history-1',
+    slug: 'history-civilization',
+    difficulty: 'easy',
+    text: 'کوروش بزرگ بنیان‌گذار کدام امپراتوری بود؟',
+    options: ['امپراتوری هخامنشی', 'امپراتوری ساسانی', 'امپراتوری عثمانی', 'امپراتوری روم'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'history-2',
+    slug: 'history-civilization',
+    difficulty: 'medium',
+    text: 'دیوار چین برای مقابله با حملات کدام اقوام ساخته شد؟',
+    options: ['مغول‌ها', 'رومی‌ها', 'اسکندر مقدونی', 'تاتارها'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'history-3',
+    slug: 'history-civilization',
+    difficulty: 'medium',
+    text: 'تمدن مصر باستان در کنار کدام رود شکل گرفت؟',
+    options: ['نیل', 'دجله', 'راین', 'آمازون'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'history-4',
+    slug: 'history-civilization',
+    difficulty: 'hard',
+    text: '«انقلاب مشروطه ایران» در چه سالی به تصویب قانون اساسی انجامید؟',
+    options: ['۱۲۸۵ خورشیدی', '۱۲۹۹ خورشیدی', '۱۳۰۴ خورشیدی', '۱۳۱۳ خورشیدی'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'geography-1',
+    slug: 'geography-nature',
+    difficulty: 'easy',
+    text: 'پایتخت کشور ژاپن کدام شهر است؟',
+    options: ['توکیو', 'اوساکا', 'هیروشیما', 'کیوتو'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'geography-2',
+    slug: 'geography-nature',
+    difficulty: 'medium',
+    text: 'کدام کوه بلندترین قله جهان به شمار می‌رود؟',
+    options: ['قله کلیمانجارو', 'قله اورست', 'قله دماوند', 'قله مون بلان'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'geography-3',
+    slug: 'geography-nature',
+    difficulty: 'medium',
+    text: 'جنگل‌های آمازون عمدتاً در کدام قاره قرار دارند؟',
+    options: ['آسیا', 'آفریقا', 'آمریکای جنوبی', 'اروپا'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'geography-4',
+    slug: 'geography-nature',
+    difficulty: 'hard',
+    text: 'دریای خزر از طریق کدام رودخانه به ولگا متصل می‌شود؟',
+    options: ['رود اترک', 'رود سفیدرود', 'کانال ولگا-دن', 'رود کورا'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'science-1',
+    slug: 'science-technology',
+    difficulty: 'easy',
+    text: 'عنصر اکسیژن با کدام حرف در جدول تناوبی نشان داده می‌شود؟',
+    options: ['O', 'Ox', 'X', 'Og'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'science-2',
+    slug: 'science-technology',
+    difficulty: 'medium',
+    text: 'واحد اندازه‌گیری توان الکتریکی چیست؟',
+    options: ['ولت', 'وات', 'اهم', 'آمپر'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'science-3',
+    slug: 'science-technology',
+    difficulty: 'medium',
+    text: 'اولین کشوری که انسان را به ماه فرستاد کدام بود؟',
+    options: ['روسیه', 'چین', 'ایالات متحده آمریکا', 'فرانسه'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'science-4',
+    slug: 'science-technology',
+    difficulty: 'hard',
+    text: 'قانون دوم ترمودینامیک درباره افزایش کدام کمیت صحبت می‌کند؟',
+    options: ['آنتروپی', 'انرژی جنبشی', 'جرم', 'دما'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'literature-1',
+    slug: 'literature-language',
+    difficulty: 'easy',
+    text: 'نویسنده مثنوی معنوی کیست؟',
+    options: ['سعدی', 'حافظ', 'مولوی', 'نظامی'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'literature-2',
+    slug: 'literature-language',
+    difficulty: 'medium',
+    text: 'کدام اثر زیر نوشته صادق هدایت است؟',
+    options: ['بوف کور', 'کلیدر', 'سمفونی مردگان', 'سووشون'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'literature-3',
+    slug: 'literature-language',
+    difficulty: 'medium',
+    text: 'در دستور زبان فارسی، «اسم» به چه معناست؟',
+    options: ['کلمه‌ای برای انجام کار', 'کلمه‌ای برای نامیدن اشیا و افراد', 'کلمه‌ای برای توصیف', 'کلمه‌ای برای اتصال جملات'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'literature-4',
+    slug: 'literature-language',
+    difficulty: 'hard',
+    text: 'رمان «جنگ و صلح» اثر کدام نویسنده روس است؟',
+    options: ['فیودور داستایوفسکی', 'آنتون چخوف', 'لئو تولستوی', 'نیکلای گوگول'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'movies-1',
+    slug: 'movies-series',
+    difficulty: 'easy',
+    text: 'فیلم «جدایی نادر از سیمین» ساخته کدام کارگردان است؟',
+    options: ['مجید مجیدی', 'اصغر فرهادی', 'بهمن قبادی', 'رضا میرکریمی'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'movies-2',
+    slug: 'movies-series',
+    difficulty: 'medium',
+    text: 'کدام سریال ایرانی با محوریت یک قصاب به نام «حاج یونس» ساخته شده است؟',
+    options: ['پدرسالار', 'وضعیت سفید', 'در پناه تو', 'مختارنامه'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'movies-3',
+    slug: 'movies-series',
+    difficulty: 'medium',
+    text: 'اسکار بهترین فیلم در سال ۱۹۹۸ به کدام فیلم تعلق گرفت؟',
+    options: ['تایتانیک', 'شکسپیر عاشق', 'نجات سرباز رایان', 'ماتریکس'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'movies-4',
+    slug: 'movies-series',
+    difficulty: 'hard',
+    text: 'موسیقی متن فیلم «پدرخوانده» اثر چه آهنگسازی است؟',
+    options: ['جان ویلیامز', 'انیو موریکونه', 'نینو روتا', 'هانس زیمر'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'sports-1',
+    slug: 'sports',
+    difficulty: 'easy',
+    text: 'فوتبال با چند بازیکن در هر تیم انجام می‌شود؟',
+    options: ['۹', '۱۰', '۱۱', '۱۲'],
+    correctIdx: 2
+  }),
+  buildFallbackQuestion({
+    id: 'sports-2',
+    slug: 'sports',
+    difficulty: 'medium',
+    text: 'کدام ورزشکار ایرانی به «اسطوره وزنه‌برداری» معروف است؟',
+    options: ['حسین رضازاده', 'بهداد سلیمی', 'نواب نصیر شلال', 'کیانوش رستمی'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'sports-3',
+    slug: 'sports',
+    difficulty: 'medium',
+    text: 'مسابقات «ویمبلدون» در کدام رشته برگزار می‌شود؟',
+    options: ['دو و میدانی', 'تنیس', 'گلف', 'بسکتبال'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'sports-4',
+    slug: 'sports',
+    difficulty: 'hard',
+    text: 'اصطلاح «سه‌گانه» در فوتبال به چه معناست؟',
+    options: ['برد در سه جام در یک فصل', 'زدن سه گل در یک بازی', 'سه پاس گل در یک نیمه', 'سه پنالتی مهار شده'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'entertainment-1',
+    slug: 'entertainment',
+    difficulty: 'easy',
+    text: 'بازی «مار و پله» با چه ابزاری انجام می‌شود؟',
+    options: ['کارت', 'صفحه و تاس', 'توپ', 'مهره‌های شطرنج'],
+    correctIdx: 1
+  }),
+  buildFallbackQuestion({
+    id: 'entertainment-2',
+    slug: 'entertainment',
+    difficulty: 'medium',
+    text: 'کدام یک از موارد زیر عنوان یک بازی ویدئویی مشهور است؟',
+    options: ['فاینال فانتزی', 'شوالیه‌های شب', 'آسمان بی‌پایان', 'جهان‌های متصل'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'entertainment-3',
+    slug: 'entertainment',
+    difficulty: 'medium',
+    text: 'در جدول کلمات متقاطع، خانه‌های سیاه چه نقشی دارند؟',
+    options: ['شروع سطر جدید را مشخص می‌کنند', 'حرف صدادار هستند', 'پاسخ درست را نشان می‌دهند', 'خانه‌های بدون استفاده هستند'],
+    correctIdx: 0
+  }),
+  buildFallbackQuestion({
+    id: 'entertainment-4',
+    slug: 'entertainment',
+    difficulty: 'hard',
+    text: 'اصطلاح «کازینو رویال» برای اولین بار در کدام سری فیلم استفاده شد؟',
+    options: ['جیمز باند', 'هری پاتر', 'ارباب حلقه‌ها', 'سریع و خشن'],
+    correctIdx: 0
+  })
+]);
 
 const DEFAULT_REMOTE_CONFIG = {
   ab: 'A',
@@ -193,8 +482,82 @@ function sanitizeDifficulty(input) {
   return DEFAULT_DIFFICULTIES.some(diff => diff.value === normalized) ? normalized : null;
 }
 
-function getFallbackQuestions() {
-  return [];
+function cloneQuestion(question, suffix = '') {
+  if (!question) return null;
+  const baseId = question.id || `fallback-${Math.random().toString(36).slice(2)}`;
+  const id = suffix ? `${baseId}-${suffix}` : baseId;
+  const options = Array.isArray(question.options) ? [...question.options] : [];
+  const choices = Array.isArray(question.choices) ? [...question.choices] : [...options];
+  return {
+    ...question,
+    id,
+    publicId: question.publicId || id,
+    options,
+    choices,
+    answerIndex: typeof question.answerIndex === 'number' ? question.answerIndex : question.correctIdx || 0,
+    correctIdx: typeof question.correctIdx === 'number' ? question.correctIdx : question.answerIndex || 0
+  };
+}
+
+function shuffleInPlace(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function normalizeCount(count) {
+  const num = Number(count);
+  if (!Number.isFinite(num)) return 5;
+  return Math.max(1, Math.min(20, Math.trunc(num)));
+}
+
+function resolveFallbackCategorySlug(categoryId) {
+  if (!categoryId) return null;
+  const canonical = resolveCategory(categoryId);
+  if (canonical?.slug) return canonical.slug;
+  if (typeof categoryId === 'string') {
+    const normalized = categoryId.trim().toLowerCase();
+    if (!normalized) return null;
+    const direct = FALLBACK_CATEGORY_DATA.find((cat) => cat.slug === normalized || cat.id === normalized);
+    if (direct) return direct.slug;
+  }
+  return null;
+}
+
+function getFallbackQuestions({ categoryId = null, difficulty = null, count = 5 } = {}) {
+  const normalizedCount = normalizeCount(count);
+  const normalizedDifficulty = sanitizeDifficulty(difficulty);
+  const slug = resolveFallbackCategorySlug(categoryId);
+
+  let pool = FALLBACK_QUESTION_DATA;
+  if (slug) {
+    pool = pool.filter((question) => question.categorySlug === slug || question.categoryId === slug);
+  }
+  if (normalizedDifficulty) {
+    const difficultyFiltered = pool.filter((question) => question.difficulty === normalizedDifficulty);
+    if (difficultyFiltered.length) {
+      pool = difficultyFiltered;
+    }
+  }
+  if (!pool.length) {
+    pool = FALLBACK_QUESTION_DATA;
+  }
+
+  const shuffled = shuffleInPlace([...pool]);
+  if (!shuffled.length) return [];
+
+  const result = [];
+  let index = 0;
+  while (result.length < normalizedCount) {
+    const question = shuffled[index % shuffled.length];
+    const cloned = cloneQuestion(question, result.length);
+    if (cloned) result.push(cloned);
+    index += 1;
+  }
+
+  return result;
 }
 
 function mapQuestionDocument(doc, categoryMap) {


### PR DESCRIPTION
## Summary
- add a localized fallback question bank covering every quiz category and difficulty tiers
- expose helper utilities to normalize category selection and clone fallback questions when building responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4ec2c0aa88326a4b36658c76be5f0