### PR TITLE
Ensure quiz questions respect selected category

### DIFF
--- a/Iquiz-assets/src/features/quiz/loader.js
+++ b/Iquiz-assets/src/features/quiz/loader.js
@@ -165,6 +165,9 @@ export async function startQuizFromAdmin(arg) {
   const catObj = findCategoryById(categoryId) || null;
   const diffPoolRaw = getCategoryDifficultyPool(catObj);
   const diffPool = Array.isArray(diffPoolRaw) && diffPoolRaw.length ? diffPoolRaw : getEffectiveDiffs();
+  const fallbackCat = firstCategory || null;
+  const catMeta = catObj || fallbackCat || {};
+  const catSlug = (catObj?.slug || catMeta?.slug || fallbackCat?.slug || firstCategory?.slug || '') || null;
 
   const selectedDiff = pickDifficulty(diffPool, {
     requested: opts.difficulty,
@@ -187,7 +190,12 @@ export async function startQuizFromAdmin(arg) {
   try {
     let list = [];
     if (typeof Api !== 'undefined' && Api && typeof Api.questions === 'function') {
-      list = (await Api.questions({ categoryId, count, difficulty: difficultyValue })) || [];
+      list = (await Api.questions({
+        categoryId,
+        categorySlug: catSlug || undefined,
+        count,
+        difficulty: difficultyValue,
+      })) || [];
     }
 
     if (!Array.isArray(list) || list.length === 0) {
@@ -201,8 +209,6 @@ export async function startQuizFromAdmin(arg) {
       return false;
     }
 
-    const fallbackCat = firstCategory || null;
-    const catMeta = catObj || fallbackCat || {};
     const stateQuizCat = State.quiz?.cat;
     const catTitle = opts.cat != null ? opts.cat : catMeta.title || catMeta.name || stateQuizCat || '—';
 

--- a/Iquiz-assets/src/services/api.js
+++ b/Iquiz-assets/src/services/api.js
@@ -10,9 +10,10 @@ export async function categories() {
   return await Net.jget(`${API_BASE}/categories`);
 }
 
-export async function questions({ categoryId, count, difficulty } = {}) {
+export async function questions({ categoryId, categorySlug, count, difficulty } = {}) {
   const qs = new URLSearchParams();
   if (categoryId) qs.set('categoryId', categoryId);
+  if (categorySlug) qs.set('categorySlug', categorySlug);
   if (count) qs.set('count', count);
   if (difficulty) qs.set('difficulty', difficulty);
   const query = qs.toString();

--- a/server/src/routes/public.routes.js
+++ b/server/src/routes/public.routes.js
@@ -196,8 +196,16 @@ router.get('/questions', async (req, res) => {
   const categoryIdRaw = typeof req.query.categoryId === 'string' ? req.query.categoryId.trim() : '';
   const categorySlugRaw = typeof req.query.categorySlug === 'string' ? req.query.categorySlug.trim() : '';
 
-  const fallbackResponse = () => {
-    res.json(getFallbackQuestions({ categoryId: categoryIdRaw || null, difficulty, count }));
+  const fallbackResponse = (candidate) => {
+    const directCandidate = typeof candidate === 'string' ? candidate.trim() : '';
+    const preferredCategory = directCandidate || categorySlugRaw || categoryIdRaw || '';
+    res.json(
+      getFallbackQuestions({
+        categoryId: preferredCategory || null,
+        difficulty,
+        count,
+      })
+    );
   };
 
   const match = {


### PR DESCRIPTION
## Summary
- include the selected category slug when requesting quiz questions so the backend can identify the intended pool
- adjust the public questions fallback logic to prioritise the provided slug and keep fallback questions scoped to the category

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4eea561fc83269d29ddc2e264c548