### PR TITLE
Add category question statistics to admin panel

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -199,6 +199,203 @@
       box-shadow: 0 16px 40px -24px rgba(30,64,175,0.65);
       transition: transform 0.25s ease, box-shadow 0.25s ease;
     }
+    #question-category-stats-card {
+      position: relative;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    #question-category-stats-card::before {
+      content: '';
+      position: absolute;
+      inset: -40% -20% auto -20%;
+      height: 70%;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.08), transparent 65%);
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.35s ease;
+    }
+    #question-category-stats-card:hover::before {
+      opacity: 1;
+    }
+    #question-category-stats-grid {
+      display: flex;
+      gap: 0.75rem;
+      min-width: 100%;
+      padding-bottom: 0.25rem;
+    }
+    .category-stat-chip {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+      min-width: 240px;
+      padding: 1.1rem 1.3rem;
+      border-radius: 1.25rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: linear-gradient(135deg, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.82));
+      color: #f8fafc;
+      cursor: pointer;
+      transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, opacity 0.25s ease;
+      text-align: right;
+      box-shadow: 0 16px 40px -28px rgba(15, 23, 42, 0.75);
+      -webkit-appearance: none;
+      appearance: none;
+    }
+    .category-stat-chip:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 28px 60px -26px rgba(14, 165, 233, 0.35);
+      border-color: rgba(125, 211, 252, 0.45);
+    }
+    .category-stat-chip:focus-visible {
+      outline: 2px solid rgba(253, 224, 71, 0.75);
+      outline-offset: 3px;
+    }
+    .category-stat-chip.active {
+      border-color: rgba(253, 224, 71, 0.7);
+      box-shadow: 0 30px 65px -28px rgba(253, 224, 71, 0.4);
+    }
+    .category-stat-chip[disabled] {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+    .category-stat-header {
+      display: flex;
+      align-items: center;
+      gap: 0.9rem;
+    }
+    .category-stat-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 1rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.3rem;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+      background: rgba(15, 23, 42, 0.4);
+      color: rgba(241, 245, 249, 0.95);
+    }
+    .category-stat-name {
+      font-size: 0.95rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+    .category-stat-sub {
+      font-size: 0.78rem;
+      color: rgba(248, 250, 252, 0.8);
+      margin-top: 0.15rem;
+    }
+    .category-stat-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem 1rem;
+      font-size: 0.75rem;
+      color: rgba(226, 232, 240, 0.85);
+    }
+    .category-stat-meta-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      white-space: nowrap;
+    }
+    .category-stat-meta-item i {
+      font-size: 0.9rem;
+      opacity: 0.8;
+    }
+    .category-stat-chip[data-color="blue"] {
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(29, 78, 216, 0.18));
+      border-color: rgba(59, 130, 246, 0.4);
+    }
+    .category-stat-chip[data-color="blue"] .category-stat-icon {
+      background: rgba(30, 64, 175, 0.45);
+      color: #dbeafe;
+    }
+    .category-stat-chip[data-color="green"] {
+      background: linear-gradient(135deg, rgba(34, 197, 94, 0.2), rgba(16, 185, 129, 0.18));
+      border-color: rgba(34, 197, 94, 0.38);
+    }
+    .category-stat-chip[data-color="green"] .category-stat-icon {
+      background: rgba(22, 163, 74, 0.45);
+      color: #bbf7d0;
+    }
+    .category-stat-chip[data-color="orange"] {
+      background: linear-gradient(135deg, rgba(249, 115, 22, 0.24), rgba(251, 146, 60, 0.18));
+      border-color: rgba(249, 115, 22, 0.4);
+    }
+    .category-stat-chip[data-color="orange"] .category-stat-icon {
+      background: rgba(251, 146, 60, 0.45);
+      color: #ffedd5;
+    }
+    .category-stat-chip[data-color="purple"] {
+      background: linear-gradient(135deg, rgba(168, 85, 247, 0.24), rgba(129, 140, 248, 0.18));
+      border-color: rgba(168, 85, 247, 0.4);
+    }
+    .category-stat-chip[data-color="purple"] .category-stat-icon {
+      background: rgba(124, 58, 237, 0.45);
+      color: #ede9fe;
+    }
+    .category-stat-chip[data-color="yellow"] {
+      background: linear-gradient(135deg, rgba(250, 204, 21, 0.26), rgba(252, 211, 77, 0.2));
+      border-color: rgba(250, 204, 21, 0.42);
+    }
+    .category-stat-chip[data-color="yellow"] .category-stat-icon {
+      background: rgba(234, 179, 8, 0.45);
+      color: #fef3c7;
+    }
+    .category-stat-chip[data-color="pink"] {
+      background: linear-gradient(135deg, rgba(244, 114, 182, 0.24), rgba(236, 72, 153, 0.18));
+      border-color: rgba(236, 72, 153, 0.38);
+    }
+    .category-stat-chip[data-color="pink"] .category-stat-icon {
+      background: rgba(219, 39, 119, 0.45);
+      color: #fce7f3;
+    }
+    .category-stat-chip[data-color="red"] {
+      background: linear-gradient(135deg, rgba(248, 113, 113, 0.24), rgba(220, 38, 38, 0.18));
+      border-color: rgba(220, 38, 38, 0.38);
+    }
+    .category-stat-chip[data-color="red"] .category-stat-icon {
+      background: rgba(185, 28, 28, 0.45);
+      color: #fee2e2;
+    }
+    .category-stat-chip[data-color="teal"] {
+      background: linear-gradient(135deg, rgba(45, 212, 191, 0.24), rgba(20, 184, 166, 0.18));
+      border-color: rgba(13, 148, 136, 0.38);
+    }
+    .category-stat-chip[data-color="teal"] .category-stat-icon {
+      background: rgba(17, 94, 89, 0.45);
+      color: #ccfbf1;
+    }
+    .category-stat-chip[data-color="indigo"] {
+      background: linear-gradient(135deg, rgba(99, 102, 241, 0.24), rgba(79, 70, 229, 0.18));
+      border-color: rgba(99, 102, 241, 0.4);
+    }
+    .category-stat-chip[data-color="indigo"] .category-stat-icon {
+      background: rgba(67, 56, 202, 0.45);
+      color: #e0e7ff;
+    }
+    .category-stat-chip[data-color="slate"] .category-stat-icon {
+      background: rgba(148, 163, 184, 0.25);
+      color: #f8fafc;
+    }
+    .category-stat-chip[data-color="slate"] {
+      background: linear-gradient(135deg, rgba(100, 116, 139, 0.22), rgba(71, 85, 105, 0.18));
+      border-color: rgba(148, 163, 184, 0.38);
+    }
+    @media (max-width: 1024px) {
+      .category-stat-chip {
+        min-width: 220px;
+      }
+    }
+    @media (max-width: 640px) {
+      #question-category-stats-grid {
+        gap: 0.6rem;
+      }
+      .category-stat-chip {
+        min-width: 200px;
+        padding: 1rem 1.1rem;
+      }
+    }
     .form-static{
       display: inline-flex;
       align-items: center;
@@ -1967,6 +2164,29 @@
               پس از تایید، سوال به صورت خودکار در تمام مسابقات عمومی نمایش داده می‌شود و نام سازنده در اپ ثبت خواهد شد.
             </div>
           </div>
+        </div>
+
+        <div id="question-category-stats-card" class="glass rounded-2xl p-5">
+          <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
+            <div>
+              <h2 class="text-lg font-bold">توزیع سوالات بر اساس دسته‌بندی</h2>
+              <p class="text-sm text-white/60 mt-1">
+                در مجموع
+                <span id="question-category-stats-total" class="font-semibold text-white">۰</span>
+                سوال در
+                <span id="question-category-stats-categories" class="font-semibold text-white">۰</span>
+                دسته‌بندی ثبت شده است.
+              </p>
+            </div>
+            <button id="question-category-stats-manage" class="btn btn-tertiary w-auto px-4">
+              <i class="fa-solid fa-layer-group ml-2"></i>
+              مدیریت دسته‌بندی‌ها
+            </button>
+          </div>
+          <div id="question-category-stats-scroll" class="overflow-x-auto pb-2">
+            <div id="question-category-stats-grid"></div>
+          </div>
+          <p id="question-category-stats-empty" class="text-sm text-white/60 mt-3 hidden">برای مشاهده آمار دسته‌بندی‌ها ابتدا وارد شوید.</p>
         </div>
 
         <!-- Filters -->


### PR DESCRIPTION
## Summary
- add a visual "question distribution" card to the questions management page that highlights each category and its question counts
- render interactive category chips that show active/inactive breakdowns, reflect the current filter, and support quick filtering
- synchronize category statistics after question CRUD operations and disable management controls when access is limited

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4f29cd58c83268b79d6db0aea5af7