### PR TITLE
Implement question deduplication and smart picker

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "seed:admin": "node src/seed/createAdmin.js",
     "fix:provider": "node scripts/backfill-jservice-provider.js",
     "cleanup:questions": "node src/scripts/cleanupQuestions.js",
+    "test": "node --test",
     "test:jservice": "curl -sf http://localhost:4000/api/jservice/random?count=1 | node -e \"const fs=require('fs');function fail(msg){console.error(msg);process.exit(1);}let raw='';try{raw=fs.readFileSync(0,'utf8');}catch(err){fail('Failed to read response');}if(!raw){fail('Empty response');}let payload;try{payload=JSON.parse(raw);}catch(err){fail('Invalid JSON');}const data=Array.isArray(payload?.data)?payload.data:[];if(!data.length){fail('Missing data');}const clue=data[0];const id=clue?.id;if(!(typeof id==='string'?id.trim().length>0:Number.isFinite(id))){fail('Invalid id');}if(typeof clue.question!=='string'||!clue.question.trim()){fail('Invalid question');}if(typeof clue.answer!=='string'||!clue.answer.trim()){fail('Invalid answer');}if(!clue.category||typeof clue.category.title!=='string'||!clue.category.title.trim()){fail('Invalid category.title');}\""
   },
   "dependencies": {

--- a/server/scripts/migrate-fingerprints.js
+++ b/server/scripts/migrate-fingerprints.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+const env = require('../src/config/env');
+const logger = require('../src/config/logger');
+const Question = require('../src/models/Question');
+const { buildFingerprints } = require('../src/services/questionIngest');
+
+const BATCH_SIZE = 2000;
+
+async function migrateFingerprints() {
+  const filter = {
+    $or: [
+      { sha1Canonical: { $exists: false } },
+      { sha1Canonical: null },
+      { simhash64: { $exists: false } },
+      { simhash64: null },
+      { lshBucket: { $exists: false } },
+      { lshBucket: null }
+    ]
+  };
+
+  const cursor = Question.find(filter).cursor();
+  let processed = 0;
+  let updated = 0;
+  let batchCount = 0;
+  let operations = [];
+
+  for await (const doc of cursor) {
+    processed += 1;
+    batchCount += 1;
+    const fingerprints = buildFingerprints(doc.text || doc.question || '');
+    const updates = {};
+
+    if (fingerprints.sha1 && doc.sha1Canonical !== fingerprints.sha1) {
+      updates.sha1Canonical = fingerprints.sha1;
+    }
+    if (fingerprints.simhash && doc.simhash64 !== fingerprints.simhash) {
+      updates.simhash64 = fingerprints.simhash;
+    }
+    if (fingerprints.bucket && doc.lshBucket !== fingerprints.bucket) {
+      updates.lshBucket = fingerprints.bucket;
+    }
+
+    if (!doc.meta || typeof doc.meta !== 'object') {
+      doc.meta = {};
+    }
+    if (fingerprints.normalized && doc.meta.normalizedText !== fingerprints.normalized) {
+      updates.meta = {
+        ...doc.meta,
+        normalizedText: fingerprints.normalized
+      };
+    }
+
+    if (Object.keys(updates).length > 0) {
+      operations.push({
+        updateOne: {
+          filter: { _id: doc._id },
+          update: { $set: updates }
+        }
+      });
+    }
+
+    if (operations.length >= BATCH_SIZE) {
+      const result = await Question.bulkWrite(operations, { ordered: false });
+      updated += result?.modifiedCount ?? result?.nModified ?? 0;
+      operations = [];
+      logger.info(`Processed ${processed} questions so far, updated ${updated}.`);
+    }
+  }
+
+  if (operations.length > 0) {
+    const result = await Question.bulkWrite(operations, { ordered: false });
+    updated += result?.modifiedCount ?? result?.nModified ?? 0;
+  }
+
+  logger.info(`Migration complete. Processed ${processed} questions, updated ${updated}.`);
+}
+
+async function main() {
+  const uri = env.mongo.uri;
+  logger.info(`Connecting to MongoDB at ${uri}`);
+  await mongoose.connect(uri, { maxPoolSize: env.mongo.maxPoolSize });
+
+  try {
+    await migrateFingerprints();
+  } catch (error) {
+    logger.error(`Migration failed: ${error.message}`);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+main().catch((error) => {
+  logger.error(`Fatal error: ${error.message}`);
+  process.exit(1);
+});

--- a/server/src/config/questions.js
+++ b/server/src/config/questions.js
@@ -1,0 +1,45 @@
+const DEFAULT_SIMHASH_HAMMING_NEAR = 3;
+const DEFAULT_LSH_PREFIX_BITS = 12;
+const DEFAULT_RECENT_KEEP = 400;
+const DEFAULT_CANDIDATE_MULTIPLIER = 8;
+const DEFAULT_HOT_BUCKET_THRESHOLD = 75;
+const DEFAULT_SESSION_TTL_SECONDS = 60 * 60; // 1 hour
+const DEFAULT_SERVE_LOG_TTL_SECONDS = 60 * 60 * 24 * 35; // 35 days for repeat metrics
+
+function parseBoolean(value, fallback = false) {
+  if (value === undefined || value === null) return fallback;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function parseNumber(value, fallback, { min, max } = {}) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  let normalized = parsed;
+  if (typeof min === 'number' && normalized < min) normalized = min;
+  if (typeof max === 'number' && normalized > max) normalized = max;
+  return normalized;
+}
+
+const config = Object.freeze({
+  SIMHASH_HAMMING_NEAR: parseNumber(process.env.SIMHASH_HAMMING_NEAR, DEFAULT_SIMHASH_HAMMING_NEAR, { min: 1, max: 16 }),
+  LSH_PREFIX_BITS: parseNumber(process.env.LSH_PREFIX_BITS, DEFAULT_LSH_PREFIX_BITS, { min: 4, max: 32 }),
+  RECENT_KEEP: parseNumber(process.env.RECENT_QUESTION_KEEP, DEFAULT_RECENT_KEEP, { min: 50, max: 2000 }),
+  CANDIDATE_MULTIPLIER: parseNumber(process.env.QUESTION_CANDIDATE_MULTIPLIER, DEFAULT_CANDIDATE_MULTIPLIER, { min: 2, max: 20 }),
+  HOT_BUCKET_THRESHOLD: parseNumber(process.env.HOT_BUCKET_THRESHOLD, DEFAULT_HOT_BUCKET_THRESHOLD, { min: 10, max: 1000 }),
+  SESSION_TTL_SECONDS: parseNumber(process.env.QUESTION_SESSION_TTL, DEFAULT_SESSION_TTL_SECONDS, { min: 60, max: 6 * 60 * 60 }),
+  SERVE_LOG_TTL_SECONDS: parseNumber(process.env.QUESTION_SERVE_LOG_TTL, DEFAULT_SERVE_LOG_TTL_SECONDS, { min: 60 * 60 * 24, max: 60 * 60 * 24 * 90 }),
+  features: {
+    useBloomFilter: parseBoolean(process.env.ENABLE_RECENT_BLOOM_FILTER, false),
+    hotBucketPenalty: parseBoolean(process.env.ENABLE_HOT_BUCKET_PENALTY, true)
+  },
+  penalties: {
+    novelty: -0.2
+  }
+});
+
+module.exports = config;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -94,6 +94,8 @@ app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/achievements', require('./routes/achievements.routes'));
 app.use('/api/ads', require('./routes/ads.routes'));
 app.use('/api/analytics', require('./routes/analytics.routes'));
+app.use('/api/admin/questions', require('./routes/admin/questions'));
+app.use('/api/admin/metrics', require('./routes/admin/metrics'));
 app.use('/api/public', require('./routes/public.routes'));
 app.use('/api/jservice', jserviceRoutes);
 app.use('/api', aiRoutes);

--- a/server/src/routes/admin/metrics.js
+++ b/server/src/routes/admin/metrics.js
@@ -1,0 +1,66 @@
+const router = require('express').Router();
+const { protect, adminOnly } = require('../../middleware/auth');
+const questionConfig = require('../../config/questions');
+const questionPicker = require('../../services/QuestionPicker');
+
+function computePercentile(values, percentile) {
+  if (!Array.isArray(values) || values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor(percentile * (sorted.length - 1))));
+  return sorted[index];
+}
+
+function computeMedian(values) {
+  if (!Array.isArray(values) || values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+router.use(protect, adminOnly);
+
+router.get('/questions/repeat-rate', async (req, res, next) => {
+  try {
+    const daysRaw = Number.parseInt(req.query.days, 10);
+    const days = Number.isFinite(daysRaw) && daysRaw > 0 ? Math.min(daysRaw, 90) : 30;
+    const store = questionPicker.getStore();
+    const entries = await store.getRepeatRates(days);
+    const rates = entries.map((entry) => entry.repeatRate);
+    res.json({
+      ok: true,
+      data: {
+        days,
+        users: entries.length,
+        medianRepeatRate: computeMedian(rates),
+        p90RepeatRate: computePercentile(rates, 0.9),
+        details: entries
+      }
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/questions/hot-buckets', async (req, res, next) => {
+  try {
+    const limitRaw = Number.parseInt(req.query.limit, 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 100) : 20;
+    const store = questionPicker.getStore();
+    const buckets = await store.getHotBuckets(limit);
+    res.json({
+      ok: true,
+      data: {
+        limit,
+        threshold: questionConfig.HOT_BUCKET_THRESHOLD,
+        buckets
+      }
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/src/routes/admin/questions.js
+++ b/server/src/routes/admin/questions.js
@@ -1,0 +1,11 @@
+const router = require('express').Router();
+const { protect, adminOnly } = require('../../middleware/auth');
+const questionsController = require('../../controllers/questions.controller');
+
+router.use(protect, adminOnly);
+
+router.post('/ingest', questionsController.create);
+router.get('/suspects', questionsController.listDuplicateSuspects);
+router.post('/:id/review', questionsController.reviewDuplicateCandidate);
+
+module.exports = router;

--- a/server/src/services/QuestionPicker.js
+++ b/server/src/services/QuestionPicker.js
@@ -1,0 +1,206 @@
+const mongoose = require('mongoose');
+const Question = require('../models/Question');
+const questionConfig = require('../config/questions');
+const { createRecentQuestionStore } = require('./recentQuestionStore');
+
+function normalizeCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 10;
+  return Math.min(Math.max(parsed, 1), 50);
+}
+
+function toObjectId(value) {
+  if (!value) return null;
+  if (value instanceof mongoose.Types.ObjectId) return value;
+  if (mongoose.Types.ObjectId.isValid(value)) {
+    return new mongoose.Types.ObjectId(value);
+  }
+  return null;
+}
+
+class QuestionPicker {
+  constructor({ QuestionModel = Question, store } = {}) {
+    this.QuestionModel = QuestionModel;
+    this.store = store || createRecentQuestionStore();
+  }
+
+  getStore() {
+    return this.store;
+  }
+
+  async getRecentIds(userId, categoryId) {
+    if (!userId || !categoryId) return [];
+    try {
+      return await this.store.getRecentIds(userId, categoryId, questionConfig.RECENT_KEEP);
+    } catch (error) {
+      return [];
+    }
+  }
+
+  async maybeLockQuestion({ userId, sessionId, questionId }) {
+    if (!questionId) return false;
+    if (sessionId && userId) {
+      const inSession = await this.store.isInSession(userId, sessionId, questionId);
+      if (inSession) {
+        return false;
+      }
+    }
+    if (userId) {
+      const locked = await this.store.acquireServeLock(userId, questionId, 5);
+      if (!locked) return false;
+    }
+    return true;
+  }
+
+  computeScore(doc, { hotBuckets }) {
+    const usageCount = Number(doc.usageCount || 0);
+    const lastServedAt = doc.lastServedAt ? new Date(doc.lastServedAt).getTime() : null;
+    const nowTs = Date.now();
+    const days = lastServedAt ? Math.max((nowTs - lastServedAt) / 86400000, 0) : 999;
+    const freshness = 1 - Math.exp(-days / 14);
+    const noveltyPenalty = hotBuckets.get(doc.lshBucket) ? questionConfig.penalties.novelty : 0;
+    const score = 0.55 * (1 / (1 + usageCount)) + 0.4 * freshness + noveltyPenalty;
+    return { score, freshness, usageCount, noveltyPenalty };
+  }
+
+  async pick({ userId, categoryId, difficulty, count = 10, sessionId }) {
+    const sanitizedCount = normalizeCount(count);
+    const recentIds = await this.getRecentIds(userId, categoryId);
+    const excludeIds = recentIds
+      .map((id) => (mongoose.Types.ObjectId.isValid(id) ? new mongoose.Types.ObjectId(id) : id))
+      .filter(Boolean);
+
+    const matchStage = {
+      active: true,
+      $or: [{ status: { $exists: false } }, { status: 'approved' }]
+    };
+
+    const categoryObjectId = toObjectId(categoryId);
+    if (categoryObjectId) {
+      matchStage.category = categoryObjectId;
+    } else if (categoryId) {
+      matchStage.category = categoryId;
+    }
+    if (difficulty) {
+      matchStage.difficulty = difficulty;
+    }
+    if (excludeIds.length) {
+      matchStage._id = { $nin: excludeIds };
+    }
+
+    const sampleSize = sanitizedCount * questionConfig.CANDIDATE_MULTIPLIER;
+    const pipeline = [
+      { $match: matchStage },
+      { $sample: { size: sampleSize } },
+      {
+        $project: {
+          text: 1,
+          options: '$choices',
+          choices: '$choices',
+          correctAnswer: 1,
+          usageCount: 1,
+          lastServedAt: 1,
+          lshBucket: 1,
+          category: 1,
+          difficulty: 1,
+          sha1Canonical: 1,
+          simhash64: 1
+        }
+      }
+    ];
+
+    let candidates = [];
+    try {
+      candidates = await this.QuestionModel.aggregate(pipeline);
+    } catch (error) {
+      return [];
+    }
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return [];
+    }
+
+    const buckets = candidates.map((doc) => doc.lshBucket).filter(Boolean);
+    const hotBuckets = await this.store.getBucketsHotness(buckets);
+    const scored = candidates.map((doc) => {
+      const { score } = this.computeScore(doc, { hotBuckets });
+      return {
+        doc,
+        score,
+        bucket: doc.lshBucket || `bucket:${String(doc._id)}`
+      };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+
+    const primary = [];
+    const fallback = [];
+    const usedBuckets = new Set();
+
+    for (const item of scored) {
+      if (primary.length >= sanitizedCount) {
+        fallback.push(item);
+        continue;
+      }
+      if (!usedBuckets.has(item.bucket)) {
+        primary.push(item);
+        usedBuckets.add(item.bucket);
+      } else {
+        fallback.push(item);
+      }
+    }
+
+    const selection = [];
+    const seenIds = new Set();
+
+    const attemptAdd = async (item) => {
+      const docId = item.doc && item.doc._id ? String(item.doc._id) : null;
+      if (!docId || seenIds.has(docId)) return false;
+      const allowed = await this.maybeLockQuestion({ userId, sessionId, questionId: docId });
+      if (!allowed) return false;
+      selection.push(item.doc);
+      seenIds.add(docId);
+      return true;
+    };
+
+    for (const item of primary) {
+      if (selection.length >= sanitizedCount) break;
+      // eslint-disable-next-line no-await-in-loop
+      await attemptAdd(item);
+    }
+
+    if (selection.length < sanitizedCount) {
+      for (const item of fallback) {
+        if (selection.length >= sanitizedCount) break;
+        // eslint-disable-next-line no-await-in-loop
+        await attemptAdd(item);
+      }
+    }
+
+    if (selection.length === 0) {
+      return [];
+    }
+
+    if (userId && categoryId) {
+      await Promise.all(
+        selection.map((doc) =>
+          this.store.recordServe({
+            userId,
+            categoryId,
+            questionId: doc._id ? String(doc._id) : doc.id,
+            bucket: doc.lshBucket || null,
+            sessionId,
+            timestamp: Date.now()
+          })
+        )
+      );
+    }
+
+    return selection.slice(0, sanitizedCount);
+  }
+}
+
+const defaultPicker = new QuestionPicker();
+
+module.exports = defaultPicker;
+module.exports.QuestionPicker = QuestionPicker;

--- a/server/src/services/questionIngest.js
+++ b/server/src/services/questionIngest.js
@@ -1,0 +1,84 @@
+const Question = require('../models/Question');
+const questionConfig = require('../config/questions');
+const {
+  normalizeFaText,
+  sha1Canonical,
+  simhash64,
+  simhashHamming,
+  lshBucket
+} = require('../utils/textFingerprint');
+
+const MAX_NEAR_DUPLICATE_CANDIDATES = 200;
+
+function buildFingerprints(text) {
+  const normalized = normalizeFaText(text);
+  const sha1 = sha1Canonical(normalized);
+  const simhash = simhash64(normalized);
+  const bucket = lshBucket(simhash, questionConfig.LSH_PREFIX_BITS);
+  return { normalized, sha1, simhash, bucket };
+}
+
+async function evaluateDuplicate({ text }, { QuestionModel = Question } = {}) {
+  if (!text) {
+    return {
+      action: 'reject',
+      statusCode: 400,
+      code: 'INVALID_TEXT',
+      message: 'Question text is required'
+    };
+  }
+
+  const fingerprints = buildFingerprints(text);
+  const { sha1, simhash, bucket } = fingerprints;
+
+  if (sha1) {
+    const existing = await QuestionModel.findOne({ sha1Canonical: sha1 }).select({ _id: 1 }).lean();
+    if (existing) {
+      return {
+        action: 'reject',
+        statusCode: 409,
+        code: 'DUPLICATE_EXACT',
+        message: 'An identical question already exists',
+        fingerprints,
+        duplicateId: String(existing._id)
+      };
+    }
+  }
+
+  if (bucket) {
+    const candidates = await QuestionModel.find({ lshBucket: bucket })
+      .select({ _id: 1, simhash64: 1 })
+      .limit(MAX_NEAR_DUPLICATE_CANDIDATES)
+      .lean();
+
+    const suspect = candidates.find((candidate) => {
+      if (!candidate?.simhash64) return false;
+      const distance = simhashHamming(simhash, candidate.simhash64);
+      return Number.isFinite(distance) && distance <= questionConfig.SIMHASH_HAMMING_NEAR;
+    });
+
+    if (suspect) {
+      return {
+        action: 'review',
+        statusCode: 202,
+        code: 'DUPLICATE_NEAR',
+        message: 'Question is similar to an existing item and requires review',
+        fingerprints,
+        duplicateId: String(suspect._id)
+      };
+    }
+  }
+
+  return {
+    action: 'allow',
+    statusCode: 201,
+    code: 'OK',
+    message: 'Question accepted',
+    fingerprints
+  };
+}
+
+module.exports = {
+  buildFingerprints,
+  evaluateDuplicate
+};

--- a/server/src/services/recentQuestionStore.js
+++ b/server/src/services/recentQuestionStore.js
@@ -1,0 +1,245 @@
+const config = require('../config/questions');
+
+function now() {
+  return Date.now();
+}
+
+function toDayKey(timestamp) {
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+class InMemoryRecentStore {
+  constructor(options = {}) {
+    this.recentLimit = options.recentLimit || config.RECENT_KEEP;
+    this.sessionTtlMs = (options.sessionTtlSeconds || config.SESSION_TTL_SECONDS) * 1000;
+    this.serveLogTtlMs = (options.serveLogTtlSeconds || config.SERVE_LOG_TTL_SECONDS) * 1000;
+    this.hotBucketThreshold = options.hotBucketThreshold || config.HOT_BUCKET_THRESHOLD;
+    this.penaltyEnabled = options.hotBucketPenalty ?? config.features.hotBucketPenalty;
+
+    this.recent = new Map(); // key -> [{ id, ts }]
+    this.sessions = new Map(); // key -> { expiresAt, ids: Set }
+    this.locks = new Map(); // key -> expiresAt
+    this.bucketCounts = new Map(); // bucket -> Map(dayKey -> count)
+    this.serveLogs = new Map(); // userId -> [{ ts, qid }]
+  }
+
+  keyRecent(userId, categoryId) {
+    if (!userId || !categoryId) return null;
+    return `recent:${userId}:${categoryId}`;
+  }
+
+  keySession(userId, sessionId) {
+    if (!userId || !sessionId) return null;
+    return `session:${userId}:${sessionId}`;
+  }
+
+  keyLock(userId, questionId) {
+    if (!userId || !questionId) return null;
+    return `lock:${userId}:${questionId}`;
+  }
+
+  pruneRecent(list) {
+    if (!Array.isArray(list)) return [];
+    const sorted = [...list].sort((a, b) => b.ts - a.ts);
+    return sorted.slice(0, this.recentLimit);
+  }
+
+  pruneSessions() {
+    const nowTs = now();
+    for (const [key, value] of this.sessions.entries()) {
+      if (!value || value.expiresAt <= nowTs) {
+        this.sessions.delete(key);
+      }
+    }
+  }
+
+  pruneLocks() {
+    const nowTs = now();
+    for (const [key, expiresAt] of this.locks.entries()) {
+      if (expiresAt <= nowTs) {
+        this.locks.delete(key);
+      }
+    }
+  }
+
+  pruneServeLogs() {
+    const nowTs = now();
+    const cutoff = nowTs - this.serveLogTtlMs;
+    for (const [userId, entries] of this.serveLogs.entries()) {
+      const filtered = entries.filter((entry) => entry.ts >= cutoff);
+      if (filtered.length) {
+        this.serveLogs.set(userId, filtered);
+      } else {
+        this.serveLogs.delete(userId);
+      }
+    }
+  }
+
+  pruneBucketCounts() {
+    const nowTs = now();
+    const minDay = toDayKey(nowTs - 2 * 24 * 60 * 60 * 1000);
+    for (const [bucket, dayMap] of this.bucketCounts.entries()) {
+      const keys = Array.from(dayMap.keys());
+      keys.forEach((dayKey) => {
+        if (dayKey < minDay) {
+          dayMap.delete(dayKey);
+        }
+      });
+      if (dayMap.size === 0) {
+        this.bucketCounts.delete(bucket);
+      }
+    }
+  }
+
+  async getRecentIds(userId, categoryId, limit = this.recentLimit) {
+    const key = this.keyRecent(userId, categoryId);
+    if (!key) return [];
+    const list = this.recent.get(key) || [];
+    const sorted = [...list].sort((a, b) => b.ts - a.ts);
+    return sorted.slice(0, limit).map((entry) => entry.id);
+  }
+
+  async addRecent(userId, categoryId, questionId, timestamp = now()) {
+    const key = this.keyRecent(userId, categoryId);
+    if (!key || !questionId) return;
+    const existing = this.recent.get(key) || [];
+    const filtered = existing.filter((entry) => entry.id !== questionId);
+    filtered.unshift({ id: questionId, ts: timestamp });
+    const pruned = this.pruneRecent(filtered);
+    this.recent.set(key, pruned);
+  }
+
+  async isInSession(userId, sessionId, questionId) {
+    this.pruneSessions();
+    const key = this.keySession(userId, sessionId);
+    if (!key || !questionId) return false;
+    const record = this.sessions.get(key);
+    if (!record || !record.ids) return false;
+    return record.ids.has(String(questionId));
+  }
+
+  async addToSession(userId, sessionId, questionIds, timestamp = now()) {
+    if (!sessionId || !userId) return;
+    this.pruneSessions();
+    const key = this.keySession(userId, sessionId);
+    if (!key) return;
+    const record = this.sessions.get(key) || { ids: new Set(), expiresAt: 0 };
+    const expiresAt = timestamp + this.sessionTtlMs;
+    const items = Array.isArray(questionIds) ? questionIds : [questionIds];
+    items.filter(Boolean).forEach((id) => record.ids.add(String(id)));
+    record.expiresAt = expiresAt;
+    this.sessions.set(key, record);
+  }
+
+  async acquireServeLock(userId, questionId, ttlSeconds = 5) {
+    this.pruneLocks();
+    const key = this.keyLock(userId, questionId);
+    if (!key) return true;
+    const nowTs = now();
+    const expiresAt = nowTs + ttlSeconds * 1000;
+    const current = this.locks.get(key) || 0;
+    if (current > nowTs) {
+      return false;
+    }
+    this.locks.set(key, expiresAt);
+    return true;
+  }
+
+  async recordServe({ userId, categoryId, questionId, bucket, sessionId, timestamp = now() }) {
+    await this.addRecent(userId, categoryId, questionId, timestamp);
+    if (sessionId) {
+      await this.addToSession(userId, sessionId, questionId, timestamp);
+    }
+    if (bucket) {
+      this.incrementBucket(bucket, timestamp);
+    }
+    if (userId && questionId) {
+      this.logServe(userId, questionId, timestamp);
+    }
+  }
+
+  incrementBucket(bucket, timestamp) {
+    const bucketKey = String(bucket || '').trim();
+    if (!bucketKey) return;
+    this.pruneBucketCounts();
+    const dayKey = toDayKey(timestamp);
+    const map = this.bucketCounts.get(bucketKey) || new Map();
+    const current = map.get(dayKey) || 0;
+    map.set(dayKey, current + 1);
+    this.bucketCounts.set(bucketKey, map);
+  }
+
+  logServe(userId, questionId, timestamp) {
+    this.pruneServeLogs();
+    const key = String(userId);
+    const list = this.serveLogs.get(key) || [];
+    list.push({ ts: timestamp, qid: String(questionId) });
+    const cutoff = now() - this.serveLogTtlMs;
+    const filtered = list.filter((entry) => entry.ts >= cutoff);
+    this.serveLogs.set(key, filtered);
+  }
+
+  async isHotBucket(bucket) {
+    if (!this.penaltyEnabled) return false;
+    const bucketKey = String(bucket || '').trim();
+    if (!bucketKey) return false;
+    this.pruneBucketCounts();
+    const map = this.bucketCounts.get(bucketKey);
+    if (!map) return false;
+    const todayKey = toDayKey(now());
+    const count = map.get(todayKey) || 0;
+    return count >= this.hotBucketThreshold;
+  }
+
+  async getBucketsHotness(buckets) {
+    const result = new Map();
+    const unique = Array.from(new Set((Array.isArray(buckets) ? buckets : []).filter(Boolean)));
+    await Promise.all(unique.map(async (bucket) => {
+      const hot = await this.isHotBucket(bucket);
+      result.set(bucket, hot);
+    }));
+    return result;
+  }
+
+  async getRepeatRates(days = 30) {
+    this.pruneServeLogs();
+    const windowMs = Math.max(1, Number(days)) * 24 * 60 * 60 * 1000;
+    const cutoff = now() - windowMs;
+    const perUser = [];
+    for (const [userId, entries] of this.serveLogs.entries()) {
+      const withinWindow = entries.filter((entry) => entry.ts >= cutoff);
+      if (withinWindow.length === 0) continue;
+      const total = withinWindow.length;
+      const unique = new Set(withinWindow.map((entry) => entry.qid)).size;
+      const repeatRate = total === 0 ? 0 : 1 - unique / total;
+      perUser.push({ userId, total, unique, repeatRate });
+    }
+    perUser.sort((a, b) => b.repeatRate - a.repeatRate);
+    return perUser;
+  }
+
+  async getHotBuckets(limit = 20) {
+    this.pruneBucketCounts();
+    const todayKey = toDayKey(now());
+    const items = [];
+    for (const [bucket, map] of this.bucketCounts.entries()) {
+      const count = map.get(todayKey) || 0;
+      if (count > 0) {
+        items.push({ bucket, count });
+      }
+    }
+    items.sort((a, b) => b.count - a.count);
+    return items.slice(0, limit);
+  }
+}
+
+module.exports = {
+  RecentQuestionStore: InMemoryRecentStore,
+  createRecentQuestionStore(options) {
+    return new InMemoryRecentStore(options);
+  }
+};

--- a/server/src/utils/textFingerprint.js
+++ b/server/src/utils/textFingerprint.js
@@ -1,0 +1,161 @@
+const crypto = require('crypto');
+
+const FNV_OFFSET_BASIS_64 = BigInt('0xcbf29ce484222325');
+const FNV_PRIME_64 = BigInt('0x100000001b3');
+const TOTAL_SIMHASH_BITS = 64;
+
+const ARABIC_CHAR_MAP = new Map([
+  ['ي', 'ی'],
+  ['ى', 'ی'],
+  ['ئ', 'ی'],
+  ['ك', 'ک'],
+  ['ؤ', 'و'],
+  ['ۀ', 'ه']
+]);
+
+const DIGIT_MAP = new Map([
+  ['۰', '0'], ['۱', '1'], ['۲', '2'], ['۳', '3'], ['۴', '4'],
+  ['۵', '5'], ['۶', '6'], ['۷', '7'], ['۸', '8'], ['۹', '9'],
+  ['٠', '0'], ['١', '1'], ['٢', '2'], ['٣', '3'], ['٤', '4'],
+  ['٥', '5'], ['٦', '6'], ['٧', '7'], ['٨', '8'], ['٩', '9']
+]);
+
+const EMOJI_REGEX = /[\u{1F300}-\u{1F6FF}\u{1F900}-\u{1F9FF}\u{1FA70}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}]/gu;
+const HTML_TAG_REGEX = /<[^>]+>/g;
+
+function normalizeFaText(input) {
+  if (input === undefined || input === null) return '';
+  let value = String(input);
+  value = value.replace(HTML_TAG_REGEX, ' ');
+  value = value.normalize('NFKC');
+
+  let normalized = '';
+  for (const char of value) {
+    EMOJI_REGEX.lastIndex = 0;
+    if (EMOJI_REGEX.test(char)) {
+      continue;
+    }
+    const mapped = ARABIC_CHAR_MAP.get(char) || DIGIT_MAP.get(char) || char;
+    normalized += mapped;
+  }
+
+  normalized = normalized
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[A-Z]/g, (c) => c.toLowerCase());
+
+  return normalized;
+}
+
+function sha1Canonical(textNormalized) {
+  const payload = typeof textNormalized === 'string' ? textNormalized : normalizeFaText(textNormalized);
+  return crypto.createHash('sha1').update(payload).digest('hex');
+}
+
+function fnv1a64(str) {
+  let hash = FNV_OFFSET_BASIS_64;
+  for (const char of str) {
+    const codePoint = char.codePointAt(0);
+    hash ^= BigInt(codePoint);
+    hash = (hash * FNV_PRIME_64) & BigInt('0xFFFFFFFFFFFFFFFF');
+  }
+  return hash;
+}
+
+function build3Grams(text) {
+  const grams = [];
+  if (!text) return grams;
+  const padded = ` ${text} `;
+  for (let i = 0; i <= padded.length - 3; i += 1) {
+    grams.push(padded.slice(i, i + 3));
+  }
+  return grams;
+}
+
+function simhash64(textNormalized) {
+  const normalized = typeof textNormalized === 'string' ? textNormalized : normalizeFaText(textNormalized);
+  const grams = build3Grams(normalized);
+  if (!grams.length) {
+    return '0'.repeat(16);
+  }
+
+  const vector = new Array(TOTAL_SIMHASH_BITS).fill(0);
+  grams.forEach((gram) => {
+    const hash = fnv1a64(gram);
+    for (let bit = 0; bit < TOTAL_SIMHASH_BITS; bit += 1) {
+      const mask = 1n << BigInt(bit);
+      if ((hash & mask) !== 0n) {
+        vector[bit] += 1;
+      } else {
+        vector[bit] -= 1;
+      }
+    }
+  });
+
+  let result = 0n;
+  for (let bit = 0; bit < TOTAL_SIMHASH_BITS; bit += 1) {
+    if (vector[bit] >= 0) {
+      result |= 1n << BigInt(bit);
+    }
+  }
+
+  const hex = result.toString(16).padStart(TOTAL_SIMHASH_BITS / 4, '0');
+  return hex;
+}
+
+function parseSimhash(value) {
+  if (value === undefined || value === null) return 0n;
+  const normalized = String(value).trim();
+  if (!normalized) return 0n;
+  if (/^[0-9a-fA-F]+$/.test(normalized)) {
+    return BigInt(`0x${normalized}`);
+  }
+  try {
+    const buffer = Buffer.from(normalized, 'base64');
+    if (buffer.length >= 8) {
+      let hash = 0n;
+      for (const byte of buffer.subarray(0, 8)) {
+        hash = (hash << 8n) | BigInt(byte);
+      }
+      return hash;
+    }
+  } catch (error) {
+    // ignore decode errors
+  }
+  return 0n;
+}
+
+function simhashHamming(a, b) {
+  const aValue = parseSimhash(a);
+  const bValue = parseSimhash(b);
+  let diff = aValue ^ bValue;
+  let count = 0;
+  while (diff) {
+    diff &= diff - 1n;
+    count += 1;
+  }
+  return count;
+}
+
+function lshBucket(simhash, prefixBits = 12) {
+  const hashValue = parseSimhash(simhash);
+  const bits = Math.min(Math.max(prefixBits, 1), TOTAL_SIMHASH_BITS);
+  const shift = TOTAL_SIMHASH_BITS - bits;
+  const masked = hashValue >> BigInt(shift);
+  const digits = Math.ceil(bits / 4);
+  return masked.toString(16).padStart(digits, '0');
+}
+
+module.exports = {
+  normalizeFaText,
+  sha1Canonical,
+  simhash64,
+  simhashHamming,
+  lshBucket,
+  // exported for tests
+  __private: {
+    fnv1a64,
+    build3Grams,
+    parseSimhash
+  }
+};

--- a/server/src/workers/questionUsage.js
+++ b/server/src/workers/questionUsage.js
@@ -1,0 +1,94 @@
+const Question = require('../models/Question');
+const logger = require('../config/logger');
+
+const FLUSH_INTERVAL_MS = 2000;
+
+const buffer = new Map();
+let flushTimer = null;
+let running = true;
+
+function minuteBucket(timestamp) {
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hour = String(date.getUTCHours()).padStart(2, '0');
+  const minute = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${year}${month}${day}${hour}${minute}`;
+}
+
+function scheduleFlush() {
+  if (!running) return;
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flush().catch((error) => {
+      logger.warn(`questionUsage flush failed: ${error.message}`);
+    });
+  }, FLUSH_INTERVAL_MS);
+}
+
+async function flush() {
+  if (buffer.size === 0) {
+    return;
+  }
+
+  const aggregated = new Map();
+  for (const { qid, ts } of buffer.values()) {
+    const key = String(qid);
+    const entry = aggregated.get(key) || { count: 0, ts: 0 };
+    entry.count += 1;
+    entry.ts = Math.max(entry.ts, ts instanceof Date ? ts.getTime() : Number(ts) || Date.now());
+    aggregated.set(key, entry);
+  }
+  buffer.clear();
+
+  const updates = [];
+  for (const [qid, payload] of aggregated.entries()) {
+    updates.push(
+      Question.updateOne(
+        { _id: qid },
+        {
+          $inc: { usageCount: payload.count },
+          $set: { lastServedAt: new Date(payload.ts) }
+        }
+      ).catch((error) => {
+        logger.warn(`Failed to update usage for question ${qid}: ${error.message}`);
+      })
+    );
+  }
+
+  await Promise.all(updates);
+}
+
+function enqueueUsage(event) {
+  if (!event || !event.qid) return;
+  const ts = event.ts ? Number(event.ts) : Date.now();
+  const bucket = minuteBucket(ts);
+  const key = `${event.qid}:${bucket}`;
+  if (buffer.has(key)) {
+    return;
+  }
+  buffer.set(key, { qid: String(event.qid), ts: new Date(ts) });
+  scheduleFlush();
+}
+
+function start() {
+  running = true;
+  scheduleFlush();
+}
+
+function stop() {
+  running = false;
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+}
+
+module.exports = {
+  enqueueUsage,
+  flush,
+  start,
+  stop
+};

--- a/server/test/questionIngest.test.js
+++ b/server/test/questionIngest.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const { evaluateDuplicate } = require('../src/services/questionIngest');
+const { normalizeFaText, simhash64, lshBucket } = require('../src/utils/textFingerprint');
+
+function createStubQuestionModel(docs) {
+  return {
+    findOne(filter) {
+      if (!filter || !filter.sha1Canonical) {
+        return { select: () => ({ lean: async () => null }) };
+      }
+      const found = docs.find((doc) => doc.sha1Canonical === filter.sha1Canonical);
+      return {
+        select() {
+          return {
+            lean: async () => (found ? { _id: found._id } : null)
+          };
+        }
+      };
+    },
+    find(filter) {
+      const bucket = filter?.lshBucket;
+      const results = docs.filter((doc) => !bucket || doc.lshBucket === bucket).map((doc) => ({
+        _id: doc._id,
+        simhash64: doc.simhash64
+      }));
+      const chain = {
+        select() {
+          return chain;
+        },
+        limit() {
+          return chain;
+        },
+        async lean() {
+          return results;
+        }
+      };
+      return chain;
+    }
+  };
+}
+
+test('evaluateDuplicate rejects exact duplicates', async () => {
+  const text = 'این سوال تکراری است؟';
+  const normalized = normalizeFaText(text);
+  const sha1 = require('crypto').createHash('sha1').update(normalized).digest('hex');
+  const model = createStubQuestionModel([
+    { _id: 'q1', sha1Canonical: sha1, simhash64: simhash64(normalized), lshBucket: lshBucket(simhash64(normalized), 12) }
+  ]);
+
+  const result = await evaluateDuplicate({ text }, { QuestionModel: model });
+  assert.strictEqual(result.action, 'reject');
+  assert.strictEqual(result.code, 'DUPLICATE_EXACT');
+  assert.strictEqual(result.statusCode, 409);
+});
+
+test('evaluateDuplicate flags near duplicates for review', async () => {
+  const near = normalizeFaText('نمونه سوال تاریخ ایران باستان؟');
+  const nearSimhash = simhash64(near);
+  const model = createStubQuestionModel([
+    { _id: 'qBase', sha1Canonical: 'abc', simhash64: nearSimhash, lshBucket: lshBucket(nearSimhash, 12) }
+  ]);
+
+  const result = await evaluateDuplicate({ text: near }, { QuestionModel: model });
+  assert.strictEqual(result.action, 'review');
+  assert.strictEqual(result.code, 'DUPLICATE_NEAR');
+  assert.strictEqual(result.statusCode, 202);
+  assert.ok(result.duplicateId);
+});
+
+test('evaluateDuplicate allows distinct questions', async () => {
+  const model = createStubQuestionModel([]);
+  const result = await evaluateDuplicate({ text: 'سوال کاملاً متفاوت درباره جغرافیا' }, { QuestionModel: model });
+  assert.strictEqual(result.action, 'allow');
+  assert.strictEqual(result.statusCode, 201);
+  assert.ok(result.fingerprints.sha1);
+});

--- a/server/test/questionPicker.test.js
+++ b/server/test/questionPicker.test.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('assert');
+const mongoose = require('mongoose');
+
+const { QuestionPicker } = require('../src/services/QuestionPicker');
+
+function createObjectId(id) {
+  if (id) return new mongoose.Types.ObjectId(id);
+  return new mongoose.Types.ObjectId();
+}
+
+function createAggregateStub(docs) {
+  return async (pipeline) => {
+    let results = docs;
+    const matchStage = pipeline.find((stage) => stage.$match);
+    if (matchStage && matchStage.$match._id && Array.isArray(matchStage.$match._id.$nin)) {
+      const exclude = matchStage.$match._id.$nin.map((id) => id.toString());
+      results = results.filter((doc) => !exclude.includes(doc._id.toString()));
+    }
+    return results;
+  };
+}
+
+class StoreStub {
+  constructor(options = {}) {
+    this.recentIds = options.recentIds || [];
+    this.sessionMembers = new Set(options.sessionMembers || []);
+    this.hotMap = options.hotMap || new Map();
+    this.lockFailures = new Set(options.lockFailures || []);
+    this.recorded = [];
+  }
+
+  async getRecentIds() {
+    return this.recentIds;
+  }
+
+  async isInSession(userId, sessionId, questionId) {
+    return this.sessionMembers.has(questionId);
+  }
+
+  async acquireServeLock(userId, questionId) {
+    if (this.lockFailures.has(questionId)) {
+      return false;
+    }
+    return true;
+  }
+
+  async getBucketsHotness(buckets) {
+    const map = new Map();
+    (buckets || []).forEach((bucket) => {
+      map.set(bucket, this.hotMap.get(bucket) || false);
+    });
+    return map;
+  }
+
+  async recordServe(payload) {
+    this.recorded.push(payload);
+  }
+}
+
+test('QuestionPicker excludes recently served questions', async () => {
+  const recentId = createObjectId('64b5fa2c8f8f0f0011111111');
+  const otherId = createObjectId('64b5fa2c8f8f0f0022222222');
+  const docs = [
+    { _id: recentId, lshBucket: 'aaa', usageCount: 5, lastServedAt: null, choices: ['1', '2', '3', '4'], correctAnswer: '1' },
+    { _id: otherId, lshBucket: 'bbb', usageCount: 0, lastServedAt: null, choices: ['a', 'b', 'c', 'd'], correctAnswer: 'a' }
+  ];
+  const store = new StoreStub({ recentIds: [recentId.toString()] });
+  const picker = new QuestionPicker({
+    QuestionModel: { aggregate: createAggregateStub(docs) },
+    store
+  });
+
+  const result = await picker.pick({
+    userId: 'user-1',
+    categoryId: '64b5fa2c8f8f0f0033333333',
+    difficulty: 'easy',
+    count: 1,
+    sessionId: 'sess-1'
+  });
+
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0]._id.toString(), otherId.toString());
+  assert.strictEqual(store.recorded.length, 1);
+  assert.strictEqual(store.recorded[0].questionId, otherId.toString());
+});
+
+test('QuestionPicker keeps diversity across buckets when possible', async () => {
+  const docA = { _id: createObjectId('64b5fa2c8f8f0f0044444444'), lshBucket: 'bucket-a', usageCount: 0, lastServedAt: null, choices: ['a1'], correctAnswer: 'a1' };
+  const docB = { _id: createObjectId('64b5fa2c8f8f0f0055555555'), lshBucket: 'bucket-b', usageCount: 1, lastServedAt: null, choices: ['b1'], correctAnswer: 'b1' };
+  const docC = { _id: createObjectId('64b5fa2c8f8f0f0066666666'), lshBucket: 'bucket-b', usageCount: 2, lastServedAt: null, choices: ['b2'], correctAnswer: 'b2' };
+  const docs = [docA, docB, docC];
+  const store = new StoreStub();
+  const picker = new QuestionPicker({ QuestionModel: { aggregate: createAggregateStub(docs) }, store });
+
+  const result = await picker.pick({ userId: 'user-2', categoryId: '64b5fa2c8f8f0f0077777777', difficulty: 'medium', count: 2, sessionId: 'sess-2' });
+  const ids = result.map((doc) => doc._id.toString());
+  assert.ok(ids.includes(docA._id.toString()));
+  assert.ok(ids.includes(docB._id.toString()));
+  assert.ok(!ids.includes(docC._id.toString()));
+});
+
+test('QuestionPicker prioritises low usage and freshness', async () => {
+  const now = Date.now();
+  const oldDate = new Date(now - 45 * 24 * 60 * 60 * 1000);
+  const recentDate = new Date(now - 2 * 24 * 60 * 60 * 1000);
+  const docFresh = { _id: createObjectId('64b5fa2c8f8f0f0088888888'), lshBucket: 'bucket-c', usageCount: 0, lastServedAt: oldDate, choices: ['f1'], correctAnswer: 'f1' };
+  const docStale = { _id: createObjectId('64b5fa2c8f8f0f0099999999'), lshBucket: 'bucket-d', usageCount: 10, lastServedAt: recentDate, choices: ['s1'], correctAnswer: 's1' };
+  const docs = [docStale, docFresh];
+  const store = new StoreStub();
+  const picker = new QuestionPicker({ QuestionModel: { aggregate: createAggregateStub(docs) }, store });
+
+  const result = await picker.pick({ userId: 'user-3', categoryId: '64b5fa2c8f8f0f0010101010', difficulty: 'hard', count: 1, sessionId: 'sess-3' });
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0]._id.toString(), docFresh._id.toString());
+});

--- a/server/test/textFingerprint.test.js
+++ b/server/test/textFingerprint.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const {
+  normalizeFaText,
+  simhash64,
+  simhashHamming,
+  lshBucket
+} = require('../src/utils/textFingerprint');
+
+test('normalizeFaText trims, collapses and normalizes Persian characters', () => {
+  const raw = '  <b>سلام</b>   دوست\u200cها\u00A0😊 123٤٥ ';
+  const normalized = normalizeFaText(raw);
+  assert.strictEqual(normalized, 'سلام دوست‌ها 12345');
+});
+
+test('simhash64 is stable across equivalent strings', () => {
+  const base = 'این یک سوال نمونه است';
+  const variant = 'اين يك سوال نمونه است';
+  const normalizedBase = normalizeFaText(base);
+  const normalizedVariant = normalizeFaText(variant);
+  const hashA = simhash64(normalizedBase);
+  const hashB = simhash64(normalizedVariant);
+  assert.strictEqual(hashA.length, 16);
+  assert.strictEqual(hashA, hashA.toLowerCase());
+  const distance = simhashHamming(hashA, hashB);
+  assert.ok(distance <= 3, `expected distance <= 3 but got ${distance}`);
+});
+
+test('lshBucket returns hex prefix of expected length', () => {
+  const hash = simhash64('متن تستی برای سطل');
+  const bucket12 = lshBucket(hash, 12);
+  const bucket20 = lshBucket(hash, 20);
+  assert.strictEqual(bucket12.length, 3);
+  assert.ok(bucket20.length >= 5);
+  assert.ok(bucket20.startsWith(bucket12));
+});


### PR DESCRIPTION
## Summary
- add fingerprint fields and supporting indexes to questions together with deduplicating admin ingest and review endpoints
- introduce text fingerprint utilities, recent-question memory, and a smart picker service with public route and admin metrics integration
- provide a usage update worker, fingerprint backfill script, and unit tests covering normalization, ingest guards, and picker behaviour

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d4f62fe3b48326aa8fcf42c0460b0f