### PR TITLE
Fix fallback quiz question selection

### DIFF
--- a/server/src/routes/public.routes.js
+++ b/server/src/routes/public.routes.js
@@ -203,7 +203,9 @@ router.get('/questions', async (req, res) => {
   const categoryIdRaw = typeof req.query.categoryId === 'string' ? req.query.categoryId.trim() : '';
   const categorySlugRaw = typeof req.query.categorySlug === 'string' ? req.query.categorySlug.trim() : '';
 
-  const fallbackPreference = (categoryIdRaw || categorySlugRaw || '').trim();
+  const fallbackPreference = [categorySlugRaw, categoryIdRaw]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find((value) => value.length > 0) || '';
 
   const fallbackResponse = (candidate) => {
     const directCandidate = typeof candidate === 'string' ? candidate.trim() : '';

--- a/server/src/services/publicContent.js
+++ b/server/src/services/publicContent.js
@@ -484,14 +484,18 @@ function sanitizeDifficulty(input) {
 
 function cloneQuestion(question, suffix = '') {
   if (!question) return null;
-  const baseId = question.id || `fallback-${Math.random().toString(36).slice(2)}`;
-  const id = suffix ? `${baseId}-${suffix}` : baseId;
+  const baseId = question.id || question.publicId || `fallback-${Math.random().toString(36).slice(2)}`;
+  const id = typeof suffix === 'number' && suffix > 0
+    ? `${baseId}-${suffix}`
+    : baseId;
+  const basePublicId = question.publicId || baseId;
+  const publicId = typeof suffix === 'number' && suffix > 0 ? `${basePublicId}-${suffix}` : basePublicId;
   const options = Array.isArray(question.options) ? [...question.options] : [];
   const choices = Array.isArray(question.choices) ? [...question.choices] : [...options];
   return {
     ...question,
     id,
-    publicId: question.publicId || id,
+    publicId,
     options,
     choices,
     answerIndex: typeof question.answerIndex === 'number' ? question.answerIndex : question.correctIdx || 0,


### PR DESCRIPTION
## Summary
- prefer the requested category slug when falling back to built-in public questions
- generate unique identifiers for cloned fallback questions so category-specific pools stay intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5041f6618832682f1fc0a71839d71