### PR TITLE
Simplify admin shop settings UI

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -3213,7 +3213,7 @@
                 <div>
                   <h2 class="text-xl font-extrabold">تنظیمات فروشگاه</h2>
                   <p class="text-sm text-white/70 mt-1">
-                    مدیریت کامل فروشگاه ربات، از بنر و پکیج‌ها تا تخفیف‌ها و پیام‌های هوشمند. هر تغییری که اینجا اعمال کنید، بلافاصله در IQuiz-bot.html قابل پیاده‌سازی است.
+                    ساده‌ترین راه برای کنترل فروشگاه تلگرام ایکویز. تنظیمات زیر برای مدیریت روزانه کافی هستند و بلافاصله روی تجربه کاربر اثر می‌گذارند.
                   </p>
                 </div>
               </div>
@@ -3230,617 +3230,281 @@
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              <div class="shop-metric-card">
-                <div class="shop-metric-label">بخش‌های فعال</div>
-                <div class="shop-metric-value" data-shop-metric="activeSections">۳ / ۳</div>
-                <div class="shop-metric-delta">کنترل نمایش ماژول‌ها</div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-1">
+                <span class="text-xs text-white/60 block">وضعیت فروشگاه</span>
+                <span class="text-lg font-bold" data-shop-summary="status">فعال</span>
+                <p class="text-xs text-white/50">کنترل سریع فعال یا غیر فعال بودن فروش.</p>
               </div>
-              <div class="shop-metric-card">
-                <div class="shop-metric-label">محصولات قابل خرید</div>
-                <div class="shop-metric-value" data-shop-metric="packages">۳</div>
-                <div class="shop-metric-delta text-white/60">کلیدها و کیف پول</div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-1">
+                <span class="text-xs text-white/60 block">پکیج‌های فعال</span>
+                <span class="text-lg font-bold" data-shop-summary="packages">۳ از ۳ فعال</span>
+                <p class="text-xs text-white/50">فقط پکیج‌های فعال به کاربران نمایش داده می‌شوند.</p>
               </div>
-              <div class="shop-metric-card">
-                <div class="shop-metric-label">پلن‌های VIP فعال</div>
-                <div class="shop-metric-value" data-shop-metric="vipPlans">۲</div>
-                <div class="shop-metric-delta text-white/60">مدیریت پیشنهاد ویژه</div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-1">
+                <span class="text-xs text-white/60 block">میانبرهای سریع</span>
+                <span class="text-lg font-bold" data-shop-summary="shortcuts">۲ میانبر فعال</span>
+                <p class="text-xs text-white/50">کنترل وضعیت دکمه شارژ و خرید آنی.</p>
               </div>
             </div>
 
-            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6" id="shop-settings-sections">
-              <div class="space-y-6 xl:col-span-2">
-
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6">
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-sliders text-sky-300"></i>
-                        <span>تنظیمات سریع فروشگاه</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">وضعیت کلی فروشگاه و حداقل تنظیمات برای شروع فروش.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-global-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-enable-toggle" data-toggle-target=".shop-lockable" data-toggle-behavior="disable" data-toggle-label-target="#shop-global-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">واحد پیش‌فرض قیمت‌گذاری</label>
-                      <select class="form-input" id="shop-pricing-currency">
-                        <option value="coin">سکه بازی</option>
-                        <option value="wallet">سکه کیف پول</option>
-                        <option value="rial">تومان</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">حداقل موجودی برای هشدار کمبود سکه</label>
-                      <input type="number" class="form-input" id="shop-low-balance-threshold" value="200" min="0">
-                    </div>
-                  </div>
-                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="rounded-2xl border border-white/10 p-4 space-y-3">
-                      <div class="flex items-start justify-between gap-3">
-                        <div>
-                          <div class="font-semibold text-sm">شارژ سریع کیف پول</div>
-                          <p class="text-xs text-white/60 mt-1">نمایش دکمه شارژ در بنر فروشگاه برای کاربران.</p>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" id="shop-quick-topup" data-toggle-target="#shop-preview-cta" data-toggle-behavior="visibility" data-toggle-on="نمایش" data-toggle-off="مخفی" checked>
-                          <span class="toggle-label" data-toggle-text>نمایش</span>
-                        </label>
-                      </div>
-                      <p class="text-xs text-white/50">متن دکمه از طریق فیلد CTA قابل ویرایش است.</p>
-                    </div>
-                    <div class="rounded-2xl border border-white/10 p-4 space-y-3">
-                      <div class="flex items-start justify-between gap-3">
-                        <div>
-                          <div class="font-semibold text-sm">خرید آنی</div>
-                          <p class="text-xs text-white/60 mt-1">اجازه خرید سریع بدون تایید دوباره برای سفارش‌های کوچک.</p>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" id="shop-quick-purchase" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                          <span class="toggle-label" data-toggle-text>فعال</span>
-                        </label>
-                      </div>
-                      <p class="text-xs text-white/50">در صورت نیاز می‌توانید سقف خرید روزانه را در تنظیمات سرور محدود کنید.</p>
-                    </div>
-                  </div>
-                  <div>
-                    <label class="block text-xs mb-1 text-white/70">یادداشت مدیریتی (نمایش در فوتر فروشگاه)</label>
-                    <textarea rows="2" class="form-input" placeholder="مثال: سفارش‌های ویژه از طریق پشتیبانی تلگرام انجام می‌شود."></textarea>
-                  </div>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 shop-lockable" data-shop-lockable>
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-bullhorn text-sky-300"></i>
-                        <span>پیام خوش‌آمد فروشگاه</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">عنوان و پیشنهاد ویژه‌ای که کاربران در اولین نگاه مشاهده می‌کنند.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-hero-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-hero-toggle" data-toggle-target="#shop-hero-quick-fields, #shop-hero-preview-card" data-toggle-label-target="#shop-hero-status" data-toggle-on="فعال" data-toggle-off="مخفی" data-shop-section-toggle checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="grid grid-cols-1 xl:grid-cols-5 gap-5">
-                    <div id="shop-hero-quick-fields" class="space-y-4 xl:col-span-3">
-                      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label class="block text-xs mb-1 text-white/70">عنوان اصلی</label>
-                          <input type="text" id="shop-hero-title" class="form-input" value="به فروشگاه ایکویز خوش آمدید" data-bind-target="#shop-hero-preview-title">
-                        </div>
-                        <div>
-                          <label class="block text-xs mb-1 text-white/70">زیرعنوان</label>
-                          <input type="text" id="shop-hero-subtitle" class="form-input" value="هر روز پیشنهادهای تازه و کلیدهای بیشتر دریافت کنید." data-bind-target="#shop-hero-preview-subtitle">
-                        </div>
-                      </div>
-                      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label class="block text-xs mb-1 text-white/70">متن دکمه CTA</label>
-                          <input type="text" id="shop-hero-cta" class="form-input" value="مشاهده پیشنهادها" data-bind-target="#shop-preview-cta-label">
-                        </div>
-                        <div>
-                          <label class="block text-xs mb-1 text-white/70">یادداشت کوتاه</label>
-                          <textarea id="shop-hero-note" rows="2" class="form-input" data-bind-target="#shop-preview-note" placeholder="مثال: ۲۰٪ تخفیف ویژه تا پایان امروز">۲۰٪ تخفیف ویژه تا پایان امروز</textarea>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="xl:col-span-2" id="shop-hero-preview-card">
-                      <div class="shop-preview" data-shop-hero-preview data-theme="sky" id="shop-hero-preview">
-                        <div class="shop-preview-header">
-                          <div class="flex items-center gap-3">
-                            <div class="w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center text-white text-xl">
-                              <i class="fas fa-store"></i>
-                            </div>
-                            <div>
-                              <div id="shop-hero-preview-title" class="text-lg font-extrabold text-white">به فروشگاه ایکویز خوش آمدید</div>
-                              <div id="shop-hero-preview-subtitle" class="text-sm text-white/80 mt-1">هر روز پیشنهادهای تازه و کلیدهای بیشتر دریافت کنید.</div>
-                            </div>
-                          </div>
-                          <div class="shop-preview-badges">
-                            <span class="shop-preview-badge" data-preview-badge="coins"><i class="fas fa-coins"></i><span>سکه: ۲٬۳۰۰</span></span>
-                            <span class="shop-preview-badge" data-preview-badge="keys"><i class="fas fa-key"></i><span>کلید: ۴</span></span>
-                          </div>
-                        </div>
-                        <div id="shop-preview-tags" class="shop-preview-badges mt-4">
-                          <span class="shop-preview-tag"><i class="fas fa-crown"></i> VIP فعال</span>
-                          <span class="shop-preview-tag"><i class="fas fa-bolt"></i> بوست امتیاز ۲ برابر</span>
-                        </div>
-                        <div class="mt-6 flex flex-wrap items-center gap-3 relative z-10">
-                          <a id="shop-preview-cta" class="shop-preview-cta" href="#wallet">
-                            <i class="fas fa-arrow-left"></i>
-                            <span id="shop-preview-cta-label">مشاهده پیشنهادها</span>
-                          </a>
-                          <span id="shop-preview-note" class="text-xs text-white/80">۲۰٪ تخفیف ویژه تا پایان امروز</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="flex justify-end">
-                  <button type="button" class="btn btn-tertiary w-full md:w-auto px-5" id="shop-advanced-toggle" aria-expanded="false">
-                    <i class="fa-solid fa-sliders"></i>
-                    <span id="shop-advanced-toggle-label">نمایش تنظیمات پیشرفته</span>
-                  </button>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 hidden" data-shop-advanced>
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-screwdriver-wrench text-sky-300"></i>
-                        <span>تنظیمات پیشرفته بنر و قیمت‌گذاری</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">گزینه‌های تکمیلی برای شخصی‌سازی ظاهر فروشگاه.</p>
-                    </div>
-                  </div>
-                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">لینک مقصد دکمه</label>
-                      <input type="url" id="shop-hero-cta-link" class="form-input" value="#wallet" placeholder="https://example.com/store">
-                    </div>
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">رنگ بنر</label>
-                      <select id="shop-hero-theme" class="form-input">
-                        <option value="sky">آبی / آسمانی</option>
-                        <option value="emerald">سبز / آبی</option>
-                        <option value="purple">بنفش / نیلی</option>
-                        <option value="amber">کهربایی / نارنجی</option>
-                      </select>
-                    </div>
-                    <div class="rounded-2xl border border-white/10 p-4 space-y-3">
-                      <div class="flex items-start justify-between gap-3">
-                        <div>
-                          <div class="font-semibold text-sm">قیمت‌گذاری پویا</div>
-                          <p class="text-xs text-white/60 mt-1">همگام‌سازی قیمت‌ها با سرویس قیمت‌گذاری شما.</p>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" id="shop-dynamic-pricing" data-toggle-on="فعال" data-toggle-off="غیرفعال">
-                          <span class="toggle-label" data-toggle-text>غیرفعال</span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                    <div class="rounded-2xl border border-white/10 p-4 space-y-3">
-                      <div class="flex items-start justify-between gap-3">
-                        <div>
-                          <div class="font-semibold text-sm">نمایش خلاصه کیف پول</div>
-                          <p class="text-xs text-white/60 mt-1">کنترل نمایش سکه و کلید در بالای بنر.</p>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" id="shop-show-balances" data-toggle-target="[data-preview-badge='coins'], [data-preview-badge='keys']" data-toggle-behavior="visibility" data-toggle-on="نمایش" data-toggle-off="مخفی" checked>
-                          <span class="toggle-label" data-toggle-text>نمایش</span>
-                        </label>
-                      </div>
-                    </div>
-                    <div class="rounded-2xl border border-white/10 p-4 space-y-3">
-                      <div class="flex items-start justify-between gap-3">
-                        <div>
-                          <div class="font-semibold text-sm">برچسب‌های ویژه</div>
-                          <p class="text-xs text-white/60 mt-1">نشان VIP و بوست‌ها در پیش‌نمایش نمایش داده شوند.</p>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" id="shop-show-tags" data-toggle-target="#shop-preview-tags" data-toggle-behavior="visibility" data-toggle-on="فعال" data-toggle-off="خاموش" checked>
-                          <span class="toggle-label" data-toggle-text>فعال</span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 shop-lockable hidden" data-shop-lockable data-shop-advanced id="shop-keys-card">
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-key text-pink-300"></i>
-                        <span>بسته‌های کلید</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">پکیج‌های کلید در کارت‌های فروشگاه و تب کلید نمایش داده می‌شوند.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-keys-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-keys-toggle" data-toggle-target="#shop-keys-table" data-toggle-behavior="disable" data-toggle-label-target="#shop-keys-status" data-toggle-on="فعال" data-toggle-off="مخفی" data-shop-section-toggle checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="space-y-4">
-                    <div class="inline-flex items-center gap-2 px-3 py-2 rounded-2xl bg-white/10 border border-white/15 text-xs font-semibold text-white/80">
-                      <i class="fas fa-info-circle"></i>
-                      <span>کد بسته‌ها باید با پیکربندی سرور همخوانی داشته باشد. مقدار «اولویت» ترتیب نمایش را مشخص می‌کند.</span>
-                    </div>
-                    <div id="shop-keys-table" class="overflow-x-auto border border-white/10 rounded-2xl">
-                      <table class="table text-sm min-w-[720px]">
-                        <thead>
-                          <tr class="text-xs uppercase tracking-wider text-white/70">
-                            <th class="text-center">فعال</th>
-                            <th>نام نمایشی</th>
-                            <th>شناسه</th>
-                            <th>تعداد کلید</th>
-                            <th>قیمت (سکه)</th>
-                            <th>اولویت</th>
-                            <th>برچسب ویژه</th>
-                            <th>توضیح کوتاه</th>
-                          </tr>
-                        </thead>
-                        <tbody class="align-top text-xs">
-                          <tr data-shop-package="keys" data-package-id="k1">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-k1-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="بسته کوچک (۱ کلید)" data-package-field="displayName" data-bind-target="#package-k1-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="k1" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="1" min="1" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="30" min="1" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="1" min="1" data-package-field="priority"></td>
-                            <td><input type="text" class="form-input text-xs" value="شروع سریع" data-package-field="badge"></td>
-                            <td><input type="text" class="form-input text-xs" value="مناسب برای شروع تجربه ایکویز." data-package-field="description"></td>
-                          </tr>
-                          <tr data-shop-package="keys" data-package-id="k3">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-k3-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="بسته اقتصادی (۳ کلید)" data-package-field="displayName" data-bind-target="#package-k3-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="k3" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="3" min="1" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="80" min="1" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="2" min="1" data-package-field="priority"></td>
-                            <td><input type="text" class="form-input text-xs" value="پیشنهاد ویژه" data-package-field="badge"></td>
-                            <td><input type="text" class="form-input text-xs" value="بهترین نسبت قیمت به کلید." data-package-field="description"></td>
-                          </tr>
-                          <tr data-shop-package="keys" data-package-id="k10">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-k10-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="بسته حرفه‌ای (۱۰ کلید)" data-package-field="displayName" data-bind-target="#package-k10-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="k10" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="10" min="1" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="250" min="1" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="3" min="1" data-package-field="priority"></td>
-                            <td><input type="text" class="form-input text-xs" value="برای رکورددارها" data-package-field="badge"></td>
-                            <td><input type="text" class="form-input text-xs" value="مناسب برای بازیکنان حرفه‌ای." data-package-field="description"></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 shop-lockable hidden" data-shop-lockable data-shop-advanced id="shop-wallet-card">
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-wallet text-emerald-300"></i>
-                        <span>بسته‌های سکه (کیف پول)</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">پکیج‌های پرداخت ریالی برای شارژ کیف پول را مدیریت کنید.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-wallet-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-wallet-toggle" data-toggle-target="#shop-wallet-table" data-toggle-behavior="disable" data-toggle-label-target="#shop-wallet-status" data-toggle-on="فعال" data-toggle-off="مخفی" data-shop-section-toggle checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="space-y-4">
-                    <div class="inline-flex items-center gap-2 px-3 py-2 rounded-2xl bg-white/10 border border-white/15 text-xs font-semibold text-white/80">
-                      <i class="fas fa-shield-halved"></i>
-                      <span>قیمت ریالی و مقدار سکه باید با پرداخت‌یار همگام باشد. مقدار بونوس برای نمایش در فروشگاه استفاده می‌شود.</span>
-                    </div>
-                    <div id="shop-wallet-table" class="overflow-x-auto border border-white/10 rounded-2xl">
-                      <table class="table text-sm min-w-[760px]">
-                        <thead>
-                          <tr class="text-xs uppercase tracking-wider text-white/70">
-                            <th class="text-center">فعال</th>
-                            <th>نام نمایشی</th>
-                            <th>شناسه</th>
-                            <th>سکه واریزی</th>
-                            <th>قیمت (تومان)</th>
-                            <th>بونوس (%)</th>
-                            <th>اولویت</th>
-                            <th>روش پرداخت</th>
-                          </tr>
-                        </thead>
-                        <tbody class="align-top text-xs">
-                          <tr data-shop-package="wallet" data-package-id="w100">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-w100-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="شارژ سریع ۱۰۰ سکه" data-package-field="displayName" data-bind-target="#package-w100-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="w100" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="100" min="0" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="49000" min="0" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="5" min="0" data-package-field="bonus"></td>
-                            <td><input type="number" class="form-input text-xs" value="1" min="0" data-package-field="priority"></td>
-                            <td>
-                              <select class="form-input text-xs" data-package-field="paymentMethod">
-                                <option>درگاه مستقیم</option>
-                                <option>درگاه بات تلگرام</option>
-                                <option>کارت به کارت</option>
-                              </select>
-                            </td>
-                          </tr>
-                          <tr data-shop-package="wallet" data-package-id="w500">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-w500-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="شارژ حرفه‌ای ۵۰۰ سکه" data-package-field="displayName" data-bind-target="#package-w500-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="w500" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="500" min="0" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="229000" min="0" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="12" min="0" data-package-field="bonus"></td>
-                            <td><input type="number" class="form-input text-xs" value="2" min="0" data-package-field="priority"></td>
-                            <td>
-                              <select class="form-input text-xs" data-package-field="paymentMethod">
-                                <option>درگاه مستقیم</option>
-                                <option>درگاه بات تلگرام</option>
-                                <option>کارت به کارت</option>
-                              </select>
-                            </td>
-                          </tr>
-                          <tr data-shop-package="wallet" data-package-id="w1200">
-                            <td class="text-center">
-                              <label class="toggle text-[10px] justify-center">
-                                <input type="checkbox" class="shop-package-toggle" data-shop-package-active data-package-field="active" data-toggle-label-target="#package-w1200-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                                <span class="toggle-label" data-toggle-text>فعال</span>
-                              </label>
-                            </td>
-                            <td><input type="text" class="form-input text-xs" value="سوپر شارژ ۱۲۰۰ سکه" data-package-field="displayName" data-bind-target="#package-w1200-name"></td>
-                            <td><input type="text" class="form-input text-xs uppercase" value="w1200" data-package-field="id"></td>
-                            <td><input type="number" class="form-input text-xs" value="1200" min="0" data-package-field="amount"></td>
-                            <td><input type="number" class="form-input text-xs" value="459000" min="0" data-package-field="price"></td>
-                            <td><input type="number" class="form-input text-xs" value="20" min="0" data-package-field="bonus"></td>
-                            <td><input type="number" class="form-input text-xs" value="3" min="0" data-package-field="priority"></td>
-                            <td>
-                              <select class="form-input text-xs" data-package-field="paymentMethod">
-                                <option>درگاه مستقیم</option>
-                                <option>درگاه بات تلگرام</option>
-                                <option>کارت به کارت</option>
-                              </select>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 shop-lockable hidden" data-shop-lockable data-shop-advanced id="shop-vip-card">
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-crown text-amber-300"></i>
-                        <span>پلن‌های اشتراک VIP</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">پلن‌های VIP محدودیت‌ها، حذف تبلیغات و مزایای ویژه را کنترل می‌کنند.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-vip-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-vip-toggle" data-toggle-target="#shop-vip-plans" data-toggle-behavior="disable" data-toggle-label-target="#shop-vip-status" data-toggle-on="فعال" data-toggle-off="مخفی" data-shop-section-toggle checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div id="shop-vip-plans" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="rounded-2xl border border-white/12 bg-white/5 p-4 space-y-4" data-shop-vip-plan data-plan-id="vip_lite" data-plan-tier="lite">
-                      <div class="flex items-center justify-between gap-3">
-                        <div class="flex items-center gap-2">
-                          <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-amber-400/20 border border-amber-300/40 text-xs font-bold text-amber-100">VIP Lite</span>
-                          <span class="text-sm text-white/80">نمایش: <span class="font-semibold text-white" data-vip-field="displayName">وی‌آی‌پی لایت</span></span>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" data-shop-vip-active data-package-field="active" data-toggle-label-target="#vip-lite-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                          <span class="toggle-label" data-toggle-text>فعال</span>
-                        </label>
-                      </div>
-                      <span id="vip-lite-status" class="hidden">فعال</span>
-                      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
-                        <div>
-                          <label class="block mb-1 text-white/70">قیمت ماهانه (تومان)</label>
-                          <input type="number" class="form-input text-xs" value="99000" min="0" data-vip-field="price">
-                        </div>
-                        <div>
-                          <label class="block mb-1 text-white/70">دوره پرداخت</label>
-                          <select class="form-input text-xs" data-vip-field="period">
-                            <option>ماهانه</option>
-                            <option>سه‌ماهه</option>
-                            <option>سالانه</option>
-                          </select>
-                        </div>
-                        <div>
-                          <label class="block mb-1 text-white/70">متن دکمه</label>
-                          <input type="text" class="form-input text-xs" value="خرید اشتراک" data-vip-field="buttonText">
-                        </div>
-                      </div>
-                      <div>
-                        <label class="block text-xs mb-1 text-white/70">مزایا (هر خط یک مورد)</label>
-                        <textarea class="form-input text-xs" rows="3" data-vip-field="benefits">حذف تبلیغات بنری
-دو برابر محدودیت روزانه کلید</textarea>
-                      </div>
-                    </div>
-                    <div class="rounded-2xl border border-amber-300/40 bg-white/5 p-4 space-y-4" data-shop-vip-plan data-plan-id="vip_pro" data-plan-tier="pro">
-                      <div class="flex items-center justify-between gap-3">
-                        <div class="flex items-center gap-2">
-                          <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-400/30 border border-yellow-200/40 text-xs font-bold text-yellow-100">VIP Pro</span>
-                          <span class="text-sm text-white/80">نمایش: <span class="font-semibold text-white" data-vip-field="displayName">وی‌آی‌پی پرو</span></span>
-                        </div>
-                        <label class="toggle text-xs">
-                          <input type="checkbox" data-shop-vip-active data-package-field="active" data-toggle-label-target="#vip-pro-status" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                          <span class="toggle-label" data-toggle-text>فعال</span>
-                        </label>
-                      </div>
-                      <span id="vip-pro-status" class="hidden">فعال</span>
-                      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
-                        <div>
-                          <label class="block mb-1 text-white/70">قیمت ماهانه (تومان)</label>
-                          <input type="number" class="form-input text-xs" value="199000" min="0" data-vip-field="price">
-                        </div>
-                        <div>
-                          <label class="block mb-1 text-white/70">دوره پرداخت</label>
-                          <select class="form-input text-xs" data-vip-field="period">
-                            <option>ماهانه</option>
-                            <option>سه‌ماهه</option>
-                            <option>سالانه</option>
-                          </select>
-                        </div>
-                        <div>
-                          <label class="block mb-1 text-white/70">متن دکمه</label>
-                          <input type="text" class="form-input text-xs" value="خرید VIP پرو" data-vip-field="buttonText">
-                        </div>
-                      </div>
-                      <div>
-                        <label class="block text-xs mb-1 text-white/70">مزایا (هر خط یک مورد)</label>
-                        <textarea class="form-input text-xs" rows="3" data-vip-field="benefits">حذف تمام تبلیغات
-دو برابر محدودیت مسابقه و کلید
-مزایای رقابتی و قاب آواتار اختصاصی</textarea>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-              <div class="space-y-6">
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-5 shop-lockable hidden" data-shop-lockable data-shop-advanced id="shop-promotions-card">
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <h3 class="text-lg font-bold flex items-center gap-2">
-                        <i class="fas fa-sparkles text-fuchsia-300"></i>
-                        <span>پروموشن‌ها و تخفیف‌ها</span>
-                      </h3>
-                      <p class="text-sm text-white/70 mt-1">مدیریت کمپین‌های تخفیف، سقف استفاده و بنرهای مناسبتی.</p>
-                    </div>
-                    <div class="flex items-center gap-3">
-                      <span id="shop-promotions-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-promotions-toggle" data-toggle-target="#shop-promotions-body" data-toggle-behavior="disable" data-toggle-label-target="#shop-promotions-status" data-toggle-on="فعال" data-toggle-off="معلق" data-shop-section-toggle checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div id="shop-promotions-body" class="space-y-4">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-                      <div>
-                        <label class="block mb-1 text-white/70">درصد تخفیف پیش‌فرض</label>
-                        <input type="number" class="form-input text-xs" value="20" min="0" max="100" data-promotions-field="defaultDiscount">
-                      </div>
-                      <div>
-                        <label class="block mb-1 text-white/70">سقف استفاده روزانه (هر کاربر)</label>
-                        <input type="number" class="form-input text-xs" value="3" min="0" data-promotions-field="dailyLimit">
-                      </div>
-                    </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-                      <div>
-                        <label class="block mb-1 text-white/70">تاریخ شروع کمپین</label>
-                        <input type="date" class="form-input text-xs" data-promotions-field="startDate">
-                      </div>
-                      <div>
-                        <label class="block mb-1 text-white/70">تاریخ پایان کمپین</label>
-                        <input type="date" class="form-input text-xs" data-promotions-field="endDate">
-                      </div>
-                    </div>
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">پیام ویژه (بنر اطلاع‌رسانی)</label>
-                      <textarea class="form-input text-xs" rows="2" data-promotions-field="bannerMessage" placeholder="مثال: جمعه سیاه؛ هر خرید سکه با ۳۰٪ هدیه.">جمعه سیاه؛ هر خرید سکه با ۳۰٪ هدیه.</textarea>
-                    </div>
-                    <div class="flex flex-wrap items-center gap-3 text-xs">
-                      <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-auto-highlight" data-toggle-on="فعال" data-toggle-off="خاموش" data-promotions-field="autoHighlight" checked>
-                        <span class="toggle-label" data-toggle-text>فعال</span>
-                      </label>
-                      <span class="text-white/60">هایلایت خودکار پکیج‌هایی که تخفیف بالای ۱۵٪ دارند.</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="glass-dark border border-white/10 rounded-2xl p-6 space-y-5 shop-lockable" data-shop-lockable id="shop-messaging-card">
+            <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
+              <section class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 lg:col-span-3">
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                   <div>
                     <h3 class="text-lg font-bold flex items-center gap-2">
-                      <i class="fas fa-comments text-sky-200"></i>
-                      <span>پیام‌ها و تجربه کاربری</span>
+                      <i class="fas fa-sliders text-sky-300"></i>
+                      <span>مدیریت سریع فروشگاه</span>
                     </h3>
-                    <p class="text-sm text-white/70 mt-1">پیام‌های راهنما، هشدار کمبود موجودی و متن دکمه‌های کمکی.</p>
+                    <p class="text-sm text-white/70">تنظیمات پایه برای شروع فروش و کنترل وضعیت.</p>
                   </div>
-                  <div class="space-y-4">
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">پیام کمبود سکه</label>
-                      <textarea class="form-input text-xs" rows="2" data-messaging-field="lowBalance" placeholder="مثال: برای ادامه مسابقه به حداقل ۵۰ سکه نیاز داری.">برای شروع مسابقه بعدی به حداقل ۵۰ سکه نیاز داری.</textarea>
-                    </div>
-                    <div>
-                      <label class="block text-xs mb-1 text-white/70">پیام موفقیت خرید</label>
-                      <textarea class="form-input text-xs" rows="2" data-messaging-field="success" placeholder="مثال: تبریک! سکه‌های جدید به حساب شما واریز شد.">تبریک! سکه‌های جدید به حساب شما واریز شد.</textarea>
-                    </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
+                  <div class="flex items-center gap-3">
+                    <span id="shop-global-status" class="text-xs font-bold tracking-widest text-emerald-300">فعال</span>
+                    <label class="toggle text-xs">
+                      <input type="checkbox" id="shop-enable-toggle" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
+                      <span class="toggle-label" data-toggle-text>فعال</span>
+                    </label>
+                  </div>
+                </div>
+                <div class="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label class="block text-xs mb-1 text-white/70">واحد پیش‌فرض قیمت‌گذاری</label>
+                    <select class="form-input" id="shop-pricing-currency">
+                      <option value="coin">سکه بازی</option>
+                      <option value="wallet">سکه کیف پول</option>
+                      <option value="rial">تومان</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-xs mb-1 text-white/70">حداقل موجودی برای هشدار کمبود سکه</label>
+                    <input type="number" class="form-input" id="shop-low-balance-threshold" value="200" min="0">
+                  </div>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <div class="rounded-2xl border border-white/10 p-4 space-y-3">
+                    <div class="flex items-start justify-between gap-3">
                       <div>
-                        <label class="block mb-1 text-white/70">متن دکمه پشتیبانی فروشگاه</label>
-                        <input type="text" class="form-input text-xs" value="ارتباط با پشتیبانی" data-messaging-field="supportCta">
+                        <div class="font-semibold text-sm">دکمه شارژ سریع</div>
+                        <p class="text-xs text-white/60 mt-1">CTA اصلی برای هدایت کاربران به کیف پول.</p>
                       </div>
-                      <div>
-                        <label class="block mb-1 text-white/70">لینک پشتیبانی</label>
-                        <input type="url" class="form-input text-xs" value="https://t.me/iquiz-support" data-messaging-field="supportLink" placeholder="https://">
-                      </div>
-                    </div>
-                    <div class="flex flex-wrap items-center gap-3 text-xs">
                       <label class="toggle text-xs">
-                        <input type="checkbox" id="shop-show-tutorial" data-toggle-on="فعال" data-toggle-off="مخفی" data-messaging-field="showTutorial" checked>
+                        <input type="checkbox" id="shop-quick-topup" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
                         <span class="toggle-label" data-toggle-text>فعال</span>
                       </label>
-                      <span class="text-white/60">نمایش راهنمای کوتاه در اولین ورود کاربر به فروشگاه.</span>
+                    </div>
+                    <p class="text-xs text-white/50">در صورت غیرفعال شدن، دکمه از بنر حذف می‌شود.</p>
+                  </div>
+                  <div class="rounded-2xl border border-white/10 p-4 space-y-3">
+                    <div class="flex items-start justify-between gap-3">
+                      <div>
+                        <div class="font-semibold text-sm">خرید آنی</div>
+                        <p class="text-xs text-white/60 mt-1">تایید فوری سفارش‌های کم‌مقدار بدون دیالوگ اضافی.</p>
+                      </div>
+                      <label class="toggle text-xs">
+                        <input type="checkbox" id="shop-quick-purchase" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
+                        <span class="toggle-label" data-toggle-text>فعال</span>
+                      </label>
+                    </div>
+                    <p class="text-xs text-white/50">برای کنترل دقیق‌تر می‌توانید سقف خرید را در سرور محدود کنید.</p>
+                  </div>
+                </div>
+              </section>
+              <section class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6 lg:col-span-2">
+                <div>
+                  <h3 class="text-lg font-bold flex items-center gap-2">
+                    <i class="fas fa-bullhorn text-sky-300"></i>
+                    <span>بنر فروشگاه و CTA</span>
+                  </h3>
+                  <p class="text-sm text-white/70 mt-1">عنوان، توضیح و لینک دکمه‌ای که کاربران می‌بینند را شخصی‌سازی کنید.</p>
+                </div>
+                <div class="space-y-4">
+                  <div class="grid gap-4">
+                    <div>
+                      <label class="block text-xs mb-1 text-white/70">عنوان اصلی</label>
+                      <input type="text" id="shop-hero-title" class="form-input" value="به فروشگاه ایکویز خوش آمدید">
+                    </div>
+                    <div>
+                      <label class="block text-xs mb-1 text-white/70">زیرعنوان</label>
+                      <input type="text" id="shop-hero-subtitle" class="form-input" value="هر روز پیشنهادهای تازه و کلیدهای بیشتر دریافت کنید.">
+                    </div>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs mb-1 text-white/70">متن دکمه CTA</label>
+                      <input type="text" id="shop-hero-cta" class="form-input" value="مشاهده پیشنهادها">
+                    </div>
+                    <div>
+                      <label class="block text-xs mb-1 text-white/70">لینک دکمه</label>
+                      <input type="url" id="shop-hero-cta-link" class="form-input" value="#wallet" placeholder="https://example.com/store">
                     </div>
                   </div>
                 </div>
-              </div>
+                <div class="rounded-2xl border border-white/10 bg-gradient-to-br from-sky-500/50 via-indigo-500/50 to-blue-700/40 p-6 space-y-4 shadow-lg" data-shop-hero-preview>
+                  <div class="flex items-center gap-3">
+                    <div class="w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center text-white text-xl">
+                      <i class="fas fa-store"></i>
+                    </div>
+                    <div class="space-y-1">
+                      <div class="text-lg font-extrabold text-white" data-shop-preview-title>به فروشگاه ایکویز خوش آمدید</div>
+                      <p class="text-sm text-white/80" data-shop-preview-subtitle>هر روز پیشنهادهای تازه و کلیدهای بیشتر دریافت کنید.</p>
+                    </div>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-3 pt-2">
+                    <a id="shop-preview-cta" class="inline-flex items-center gap-2 rounded-full bg-white text-slate-900 px-4 py-2 text-xs font-bold shadow-md transition hover:-translate-y-0.5" href="#wallet">
+                      <i class="fas fa-arrow-left"></i>
+                      <span data-shop-preview-cta-label>مشاهده پیشنهادها</span>
+                    </a>
+                    <span class="text-xs text-white/80" data-shop-preview-helper>CTA برای هدایت سریع کاربران</span>
+                  </div>
+                </div>
+              </section>
             </div>
+
+            <section class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6">
+              <div>
+                <h3 class="text-lg font-bold flex items-center gap-2">
+                  <i class="fas fa-boxes-stacked text-amber-300"></i>
+                  <span>پکیج‌های فروشگاهی</span>
+                </h3>
+                <p class="text-sm text-white/70 mt-1">پکیج‌های پیشنهادی را ساده و قابل‌فهم نگه دارید. در صورت نیاز می‌توانید مقادیر را ویرایش کنید.</p>
+              </div>
+              <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div class="rounded-2xl border border-white/10 bg-slate-900/60 p-5 space-y-4 transition hover:border-white/20" data-shop-package="keys" data-package-id="k1">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="space-y-1">
+                      <p class="text-xs text-white/60">پکیج پایه</p>
+                      <h4 class="text-sm font-bold" data-package-name>بسته کوچک (۱ کلید)</h4>
+                    </div>
+                    <label class="toggle text-xs">
+                      <input type="checkbox" data-shop-package-active data-package-field="active" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
+                      <span class="toggle-label" data-toggle-text>فعال</span>
+                    </label>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">عنوان نمایشی</label>
+                      <input type="text" class="form-input text-sm" data-package-field="displayName" value="بسته کوچک (۱ کلید)">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">تعداد کلید</label>
+                      <input type="number" class="form-input text-sm" data-package-field="amount" value="1" min="1">
+                    </div>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">قیمت (سکه)</label>
+                      <input type="number" class="form-input text-sm" data-package-field="price" value="30" min="1">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">برچسب کوتاه</label>
+                      <input type="text" class="form-input text-sm" data-package-field="badge" value="شروع سریع">
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs text-white/60 mb-1">توضیح کوتاه</label>
+                    <textarea class="form-input text-sm" rows="2" data-package-field="description">مناسب برای شروع تجربه ایکویز.</textarea>
+                  </div>
+                  <input type="hidden" data-package-field="id" value="k1">
+                  <input type="hidden" data-package-field="priority" value="1">
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-slate-900/60 p-5 space-y-4 transition hover:border-white/20" data-shop-package="keys" data-package-id="k3">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="space-y-1">
+                      <p class="text-xs text-white/60">پکیج منتخب</p>
+                      <h4 class="text-sm font-bold" data-package-name>بسته اقتصادی (۳ کلید)</h4>
+                    </div>
+                    <label class="toggle text-xs">
+                      <input type="checkbox" data-shop-package-active data-package-field="active" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
+                      <span class="toggle-label" data-toggle-text>فعال</span>
+                    </label>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">عنوان نمایشی</label>
+                      <input type="text" class="form-input text-sm" data-package-field="displayName" value="بسته اقتصادی (۳ کلید)">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">تعداد کلید</label>
+                      <input type="number" class="form-input text-sm" data-package-field="amount" value="3" min="1">
+                    </div>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">قیمت (سکه)</label>
+                      <input type="number" class="form-input text-sm" data-package-field="price" value="80" min="1">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">برچسب کوتاه</label>
+                      <input type="text" class="form-input text-sm" data-package-field="badge" value="پیشنهاد ویژه">
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs text-white/60 mb-1">توضیح کوتاه</label>
+                    <textarea class="form-input text-sm" rows="2" data-package-field="description">بهترین نسبت قیمت به کلید.</textarea>
+                  </div>
+                  <input type="hidden" data-package-field="id" value="k3">
+                  <input type="hidden" data-package-field="priority" value="2">
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-slate-900/60 p-5 space-y-4 transition hover:border-white/20" data-shop-package="keys" data-package-id="k10">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="space-y-1">
+                      <p class="text-xs text-white/60">پکیج حرفه‌ای</p>
+                      <h4 class="text-sm font-bold" data-package-name>بسته حرفه‌ای (۱۰ کلید)</h4>
+                    </div>
+                    <label class="toggle text-xs">
+                      <input type="checkbox" data-shop-package-active data-package-field="active" data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
+                      <span class="toggle-label" data-toggle-text>فعال</span>
+                    </label>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">عنوان نمایشی</label>
+                      <input type="text" class="form-input text-sm" data-package-field="displayName" value="بسته حرفه‌ای (۱۰ کلید)">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">تعداد کلید</label>
+                      <input type="number" class="form-input text-sm" data-package-field="amount" value="10" min="1">
+                    </div>
+                  </div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">قیمت (سکه)</label>
+                      <input type="number" class="form-input text-sm" data-package-field="price" value="250" min="1">
+                    </div>
+                    <div>
+                      <label class="block text-xs text-white/60 mb-1">برچسب کوتاه</label>
+                      <input type="text" class="form-input text-sm" data-package-field="badge" value="برای رکورددارها">
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs text-white/60 mb-1">توضیح کوتاه</label>
+                    <textarea class="form-input text-sm" rows="2" data-package-field="description">مناسب برای بازیکنان حرفه‌ای.</textarea>
+                  </div>
+                  <input type="hidden" data-package-field="id" value="k10">
+                  <input type="hidden" data-package-field="priority" value="3">
+                </div>
+              </div>
+            </section>
+
+            <section class="glass-dark border border-white/10 rounded-2xl p-6 space-y-6">
+              <div>
+                <h3 class="text-lg font-bold flex items-center gap-2">
+                  <i class="fas fa-headset text-sky-200"></i>
+                  <span>پیام پشتیبانی فروشگاه</span>
+                </h3>
+                <p class="text-sm text-white/70 mt-1">یک پیام کوتاه و لینک مستقیم برای ارتباط کاربران با تیم شما.</p>
+              </div>
+              <div class="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label class="block text-xs text-white/60 mb-1">متن نمایش داده شده در فوتر فروشگاه</label>
+                  <textarea id="shop-support-message" rows="2" class="form-input text-sm" placeholder="مثال: برای سفارش ویژه به پشتیبانی پیام دهید.">سوال یا درخواست خاص داری؟ تیم ما در تلگرام پاسخگوست.</textarea>
+                </div>
+                <div>
+                  <label class="block text-xs text-white/60 mb-1">لینک پشتیبانی</label>
+                  <input type="url" id="shop-support-link" class="form-input text-sm" value="https://t.me/iquiz-support" placeholder="https://">
+                  <p class="text-xs text-white/40 mt-2">این لینک در پایین صفحه فروشگاه نمایش داده می‌شود.</p>
+                </div>
+              </div>
+            </section>
           </div>
           <!-- Notification Settings -->
           <div class="glass rounded-2xl p-6">

--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -534,28 +534,33 @@ const shopGlobalToggle = $('#shop-enable-toggle');
 const shopStatusChip = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-status-chip]') : null;
 const shopStatusLabel = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-status-label]') : null;
 const shopLastUpdateEl = shopSettingsPage ? shopSettingsPage.querySelector('#shop-last-update') : null;
-const shopMetricElements = {
-  activeSections: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-metric="activeSections"]') : null,
-  packages: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-metric="packages"]') : null,
-  vipPlans: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-metric="vipPlans"]') : null
+const shopSummaryElements = {
+  status: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-summary="status"]') : null,
+  packages: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-summary="packages"]') : null,
+  shortcuts: shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-summary="shortcuts"]') : null
 };
-const shopLockableSections = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-lockable]')) : [];
-const shopSectionToggles = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-section-toggle]')) : [];
-const shopPackageToggles = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-package-active]')) : [];
-const shopVipToggles = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-vip-active]')) : [];
+const shopGlobalStatusLabel = shopSettingsPage ? shopSettingsPage.querySelector('#shop-global-status') : null;
 const shopHeroPreview = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-hero-preview]') : null;
-const shopHeroThemeSelect = $('#shop-hero-theme');
-const shopHeroLinkInput = $('#shop-hero-cta-link');
+const shopHeroPreviewTitle = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-preview-title]') : null;
+const shopHeroPreviewSubtitle = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-preview-subtitle]') : null;
 const shopPreviewCta = $('#shop-preview-cta');
-const shopBoundInputs = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-bind-target]')) : [];
-const shopHeroToggle = $('#shop-hero-toggle');
-const shopKeysToggle = $('#shop-keys-toggle');
-const shopWalletToggle = $('#shop-wallet-toggle');
-const shopVipToggle = $('#shop-vip-toggle');
-const shopPromotionsToggle = $('#shop-promotions-toggle');
-const shopAdvancedToggleBtn = $('#shop-advanced-toggle');
-const shopAdvancedToggleLabel = $('#shop-advanced-toggle-label');
-const shopAdvancedSections = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-advanced]')) : [];
+const shopPreviewCtaLabel = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-preview-cta-label]') : null;
+const shopPreviewHelper = shopSettingsPage ? shopSettingsPage.querySelector('[data-shop-preview-helper]') : null;
+const shopHeroTitleInput = $('#shop-hero-title');
+const shopHeroSubtitleInput = $('#shop-hero-subtitle');
+const shopHeroCtaInput = $('#shop-hero-cta');
+const shopHeroLinkInput = $('#shop-hero-cta-link');
+const shopPricingCurrencySelect = $('#shop-pricing-currency');
+const shopLowBalanceThresholdInput = $('#shop-low-balance-threshold');
+const shopQuickTopupToggle = $('#shop-quick-topup');
+const shopQuickPurchaseToggle = $('#shop-quick-purchase');
+const shopSupportMessageInput = $('#shop-support-message');
+const shopSupportLinkInput = $('#shop-support-link');
+const shopPackageCards = shopSettingsPage ? Array.from(shopSettingsPage.querySelectorAll('[data-shop-package]')) : [];
+const shopState = {
+  initialized: false,
+  lastUpdated: null
+};
 const settingsSaveButton = $('#settings-save-button');
 const generalAppNameInput = $('#settings-app-name');
 const generalLanguageSelect = $('#settings-language');
@@ -565,19 +570,6 @@ const rewardPointsCorrectInput = $('#settings-points-correct');
 const rewardCoinsCorrectInput = $('#settings-coins-correct');
 const rewardPointsStreakInput = $('#settings-points-streak');
 const rewardCoinsStreakInput = $('#settings-coins-streak');
-const shopPricingCurrencySelect = $('#shop-pricing-currency');
-const shopLowBalanceThresholdInput = $('#shop-low-balance-threshold');
-const shopQuickTopupToggle = $('#shop-quick-topup');
-const shopQuickPurchaseToggle = $('#shop-quick-purchase');
-const shopDynamicPricingToggle = $('#shop-dynamic-pricing');
-const shopHeroTitleInput = $('#shop-hero-title');
-const shopHeroSubtitleInput = $('#shop-hero-subtitle');
-const shopHeroCtaInput = $('#shop-hero-cta');
-const shopHeroNoteInput = $('#shop-hero-note');
-const shopShowBalancesToggle = $('#shop-show-balances');
-const shopShowTagsToggle = $('#shop-show-tags');
-const shopAutoHighlightToggle = $('#shop-auto-highlight');
-const shopShowTutorialToggle = $('#shop-show-tutorial');
 
 const questionFilters = {
   category: '',
@@ -5767,104 +5759,7 @@ function setCheckboxValue(input, value) {
   input.checked = !!value;
 }
 
-function applyPackageSettings(type, packages) {
-  if (!shopSettingsPage || !Array.isArray(packages)) return;
-  packages.forEach((pkg) => {
-    if (!pkg || !pkg.id) return;
-    const row = shopSettingsPage.querySelector(`[data-shop-package="${type}"][data-package-id="${pkg.id}"]`);
-    if (!row) return;
-    row.querySelectorAll('[data-package-field]').forEach((input) => {
-      const field = input.dataset.packageField;
-      if (!field) return;
-      if (input.type === 'checkbox') {
-        input.checked = pkg[field] !== false && !!pkg[field];
-      } else if (input.type === 'number') {
-        if (pkg[field] != null) input.value = pkg[field];
-      } else if (input.tagName === 'SELECT') {
-        if (pkg[field] != null) {
-          setSelectValue(input, pkg[field]);
-        }
-      } else if (pkg[field] != null) {
-        input.value = pkg[field];
-      }
-    });
-  });
-}
-
-function applyVipSettings(plans) {
-  if (!shopSettingsPage || !Array.isArray(plans)) return;
-  plans.forEach((plan) => {
-    if (!plan) return;
-    const selector = plan.id
-      ? `[data-shop-vip-plan][data-plan-id="${plan.id}"]`
-      : plan.tier
-        ? `[data-shop-vip-plan][data-plan-tier="${plan.tier}"]`
-        : '';
-    if (!selector) return;
-    const container = shopSettingsPage.querySelector(selector);
-    if (!container) return;
-    const activeToggle = container.querySelector('[data-shop-vip-active]');
-    if (activeToggle) activeToggle.checked = plan.active !== false && !!plan.active;
-    const displayEl = container.querySelector('[data-vip-field="displayName"]');
-    if (displayEl && plan.displayName != null) displayEl.textContent = plan.displayName;
-    const priceInput = container.querySelector('[data-vip-field="price"]');
-    if (priceInput && plan.price != null) priceInput.value = plan.price;
-    const periodSelect = container.querySelector('[data-vip-field="period"]');
-    if (periodSelect && plan.period != null) setSelectValue(periodSelect, plan.period);
-    const buttonInput = container.querySelector('[data-vip-field="buttonText"]');
-    if (buttonInput && plan.buttonText != null) buttonInput.value = plan.buttonText;
-    const benefitsTextarea = container.querySelector('[data-vip-field="benefits"]');
-    if (benefitsTextarea) {
-      if (Array.isArray(plan.benefits)) {
-        benefitsTextarea.value = plan.benefits.join('\n');
-      } else if (plan.benefits != null) {
-        benefitsTextarea.value = plan.benefits;
-      }
-    }
-  });
-}
-
-function applyPromotionsSettings(promotions) {
-  if (!shopSettingsPage || !promotions || typeof promotions !== 'object') return;
-  const setField = (field, value) => {
-    const el = shopSettingsPage.querySelector(`[data-promotions-field="${field}"]`);
-    if (!el || value == null) return;
-    if (el.type === 'checkbox') {
-      el.checked = !!value;
-    } else {
-      el.value = value;
-    }
-  };
-  setField('defaultDiscount', promotions.defaultDiscount);
-  setField('dailyLimit', promotions.dailyLimit);
-  setField('startDate', promotions.startDate);
-  setField('endDate', promotions.endDate);
-  setField('bannerMessage', promotions.bannerMessage);
-  if (shopAutoHighlightToggle) shopAutoHighlightToggle.checked = promotions.autoHighlight !== false && !!promotions.autoHighlight;
-}
-
-function applyMessagingSettings(messaging) {
-  if (!shopSettingsPage || !messaging || typeof messaging !== 'object') return;
-  const setField = (field, value) => {
-    const el = shopSettingsPage.querySelector(`[data-messaging-field="${field}"]`);
-    if (!el || value == null) return;
-    el.value = value;
-  };
-  setField('lowBalance', messaging.lowBalance);
-  setField('success', messaging.success);
-  setField('supportCta', messaging.supportCta);
-  setField('supportLink', messaging.supportLink);
-  if (shopShowTutorialToggle) shopShowTutorialToggle.checked = messaging.showTutorial !== false && !!messaging.showTutorial;
-}
-
-function applySectionsState(sections) {
-  if (!sections || typeof sections !== 'object') return;
-  if (shopHeroToggle && sections.hero != null) shopHeroToggle.checked = !!sections.hero;
-  if (shopKeysToggle && sections.keys != null) shopKeysToggle.checked = !!sections.keys;
-  if (shopWalletToggle && sections.wallet != null) shopWalletToggle.checked = !!sections.wallet;
-  if (shopVipToggle && sections.vip != null) shopVipToggle.checked = !!sections.vip;
-  if (shopPromotionsToggle && sections.promotions != null) shopPromotionsToggle.checked = !!sections.promotions;
-}
+// legacy helpers removed in simplified shop settings
 
 function applySettingsSnapshot(snapshot) {
   if (!snapshot || typeof snapshot !== 'object') return;
@@ -5882,36 +5777,43 @@ function applySettingsSnapshot(snapshot) {
 
   const shop = snapshot.shop || {};
   if (shopGlobalToggle && shop.enabled != null) shopGlobalToggle.checked = !!shop.enabled;
+  updateShopStatus(getCheckboxValue(shopGlobalToggle, true));
+
   if (shopPricingCurrencySelect && shop.currency != null) setSelectValue(shopPricingCurrencySelect, shop.currency);
   if (shopLowBalanceThresholdInput && shop.lowBalanceThreshold != null) shopLowBalanceThresholdInput.value = shop.lowBalanceThreshold;
-  if (shopQuickTopupToggle) shopQuickTopupToggle.checked = !!shop.quickTopup;
-  if (shopQuickPurchaseToggle) shopQuickPurchaseToggle.checked = !!shop.quickPurchase;
-  if (shopDynamicPricingToggle) shopDynamicPricingToggle.checked = !!shop.dynamicPricing;
+  if (shopQuickTopupToggle) shopQuickTopupToggle.checked = shop.quickTopup !== false && !!shop.quickTopup;
+  if (shopQuickPurchaseToggle) shopQuickPurchaseToggle.checked = shop.quickPurchase !== false && !!shop.quickPurchase;
 
-  if (shop.hero && typeof shop.hero === 'object') {
-    const hero = shop.hero;
-    if (shopHeroTitleInput && hero.title != null) shopHeroTitleInput.value = hero.title;
-    if (shopHeroSubtitleInput && hero.subtitle != null) shopHeroSubtitleInput.value = hero.subtitle;
-    if (shopHeroCtaInput && hero.ctaText != null) shopHeroCtaInput.value = hero.ctaText;
-    if (shopHeroLinkInput && hero.ctaLink != null) shopHeroLinkInput.value = hero.ctaLink;
-    if (shopHeroThemeSelect && hero.theme != null) setSelectValue(shopHeroThemeSelect, hero.theme);
-    if (shopHeroNoteInput && hero.note != null) shopHeroNoteInput.value = hero.note;
-    if (shopShowBalancesToggle) shopShowBalancesToggle.checked = hero.showBalances !== false && !!hero.showBalances;
-    if (shopShowTagsToggle) shopShowTagsToggle.checked = hero.showTags !== false && !!hero.showTags;
-  }
+  const hero = shop.hero || {};
+  if (shopHeroTitleInput && hero.title != null) shopHeroTitleInput.value = hero.title;
+  if (shopHeroSubtitleInput && hero.subtitle != null) shopHeroSubtitleInput.value = hero.subtitle;
+  if (shopHeroCtaInput && hero.ctaText != null) shopHeroCtaInput.value = hero.ctaText;
+  if (shopHeroLinkInput && hero.ctaLink != null) shopHeroLinkInput.value = hero.ctaLink;
 
-  applySectionsState(shop.sections);
-  applyPackageSettings('keys', (shop.packages && shop.packages.keys) || shop.keys);
-  applyPackageSettings('wallet', (shop.packages && shop.packages.wallet) || shop.wallet);
-  applyVipSettings(shop.vip);
-  applyPromotionsSettings(shop.promotions);
-  applyMessagingSettings(shop.messaging);
+  const packagesData = shop.packages != null ? shop.packages : snapshot.packages;
+  applyPackageSnapshots(packagesData);
 
-  if (shopBoundInputs && shopBoundInputs.length) {
-    shopBoundInputs.forEach((input) => updateBoundTargets(input));
-  }
-  if (typeof updateHeroTheme === 'function') updateHeroTheme();
-  if (typeof updateHeroLink === 'function') updateHeroLink();
+  const support = shop.support || {};
+  if (shopSupportMessageInput && support.message != null) shopSupportMessageInput.value = support.message;
+  if (shopSupportLinkInput && support.link != null) shopSupportLinkInput.value = support.link;
+
+  shopPackageCards.forEach((card) => {
+    const nameInput = card.querySelector('[data-package-field="displayName"]');
+    const nameEl = card.querySelector('[data-package-name]');
+    if (nameInput && nameEl) {
+      const value = safeString(nameInput.value, '');
+      nameEl.textContent = value || '—';
+    }
+    const toggle = card.querySelector('[data-shop-package-active]');
+    syncToggleLabel(toggle);
+  });
+
+  syncToggleLabel(shopGlobalToggle);
+  syncToggleLabel(shopQuickTopupToggle);
+  syncToggleLabel(shopQuickPurchaseToggle);
+
+  updateHeroPreview();
+  updateShopSummary();
 }
 
 function collectGeneralSettings() {
@@ -5932,78 +5834,94 @@ function collectRewardSettings() {
   };
 }
 
-function collectPackageRows(type) {
-  if (!shopSettingsPage) return [];
-  return Array.from(shopSettingsPage.querySelectorAll(`[data-shop-package="${type}"]`)).map((row) => {
-    const pkg = {};
-    const defaultId = safeString(row.dataset.packageId || '', '');
-    row.querySelectorAll('[data-package-field]').forEach((input) => {
-      const field = input.dataset.packageField;
-      if (!field) return;
-      if (input.type === 'checkbox') {
-        pkg[field] = !!input.checked;
-      } else if (input.type === 'number') {
-        pkg[field] = safeNumber(input.value, 0);
-      } else if (input.tagName === 'SELECT') {
-        pkg[field] = safeString(input.value, '');
-      } else {
-        pkg[field] = safeString(input.value, '');
+function readPackageCard(card) {
+  if (!card) return null;
+  const pkg = {};
+  const defaultId = safeString(card.dataset.packageId || '', '');
+  card.querySelectorAll('[data-package-field]').forEach((input) => {
+    const field = input.dataset.packageField;
+    if (!field) return;
+    if (input.type === 'checkbox') {
+      pkg[field] = !!input.checked;
+    } else if (input.type === 'number') {
+      pkg[field] = safeNumber(input.value, 0);
+    } else {
+      pkg[field] = safeString(input.value, '');
+    }
+  });
+  pkg.id = safeString(pkg.id || defaultId, defaultId);
+  pkg.type = safeString(card.dataset.shopPackage || 'general', 'general');
+  if (!pkg.id) return null;
+  return pkg;
+}
+
+function applyPackageSnapshots(packages) {
+  if (!shopSettingsPage) return;
+  const normalized = [];
+  if (Array.isArray(packages)) {
+    packages.forEach((pkg) => {
+      if (pkg) normalized.push(pkg);
+    });
+  } else if (packages && typeof packages === 'object') {
+    Object.entries(packages).forEach(([type, items]) => {
+      if (!Array.isArray(items)) return;
+      items.forEach((item) => {
+        if (!item) return;
+        normalized.push({ ...item, type });
+      });
+    });
+  }
+
+  if (!normalized.length) {
+    shopPackageCards.forEach((card) => {
+      const nameInput = card.querySelector('[data-package-field="displayName"]');
+      const nameEl = card.querySelector('[data-package-name]');
+      if (nameInput && nameEl) {
+        const value = safeString(nameInput.value, '');
+        nameEl.textContent = value || '—';
       }
     });
-    pkg.id = safeString(pkg.id != null ? pkg.id : defaultId, defaultId);
-    if (!pkg.id) return null;
-    pkg.displayName = safeString(pkg.displayName != null ? pkg.displayName : '', '');
-    return pkg;
-  }).filter(Boolean);
-}
+    return;
+  }
 
-function collectVipPlansSnapshot() {
-  if (!shopSettingsPage) return [];
-  return Array.from(shopSettingsPage.querySelectorAll('[data-shop-vip-plan]')).map((container) => {
-    const id = safeString(container.dataset.planId || container.dataset.planTier || '', '');
-    if (!id) return null;
-    const tier = safeString(container.dataset.planTier || container.dataset.planId || '', '');
-    const plan = {
-      id,
-      tier,
-      active: getCheckboxValue(container.querySelector('[data-shop-vip-active]'), true),
-      displayName: safeString((container.querySelector('[data-vip-field="displayName"]') || {}).textContent || '', ''),
-      price: safeNumber((container.querySelector('[data-vip-field="price"]') || {}).value, 0),
-      period: safeString((container.querySelector('[data-vip-field="period"]') || {}).value, ''),
-      buttonText: safeString((container.querySelector('[data-vip-field="buttonText"]') || {}).value, ''),
-      benefits: []
-    };
-    const benefitsTextarea = container.querySelector('[data-vip-field="benefits"]');
-    if (benefitsTextarea) {
-      plan.benefits = benefitsTextarea.value
-        .split(/\r?\n/)
-        .map((line) => safeString(line, ''))
-        .filter((line) => line.length > 0);
+  normalized.forEach((pkg) => {
+    if (!pkg || !pkg.id) return;
+    const selector = `[data-shop-package][data-package-id="${pkg.id}"]`;
+    const card = shopSettingsPage.querySelector(selector);
+    if (!card) return;
+    card.querySelectorAll('[data-package-field]').forEach((input) => {
+      const field = input.dataset.packageField;
+      if (!field) return;
+      const value = pkg[field];
+      if (value == null) return;
+      if (input.type === 'checkbox') {
+        input.checked = value !== false && !!value;
+      } else if (input.type === 'number') {
+        input.value = value;
+      } else {
+        input.value = value;
+      }
+    });
+    const nameEl = card.querySelector('[data-package-name]');
+    if (nameEl && pkg.displayName != null) {
+      nameEl.textContent = safeString(pkg.displayName, '') || '—';
     }
-    return plan;
-  }).filter(Boolean);
+  });
 }
 
-function collectPromotionsSnapshot() {
-  const promotions = {
-    defaultDiscount: safeNumber((shopSettingsPage?.querySelector('[data-promotions-field="defaultDiscount"]') || {}).value, 0),
-    dailyLimit: safeNumber((shopSettingsPage?.querySelector('[data-promotions-field="dailyLimit"]') || {}).value, 0),
-    startDate: safeString((shopSettingsPage?.querySelector('[data-promotions-field="startDate"]') || {}).value, ''),
-    endDate: safeString((shopSettingsPage?.querySelector('[data-promotions-field="endDate"]') || {}).value, ''),
-    bannerMessage: safeString((shopSettingsPage?.querySelector('[data-promotions-field="bannerMessage"]') || {}).value, ''),
-    autoHighlight: getCheckboxValue(shopAutoHighlightToggle, true)
-  };
-  return promotions;
-}
-
-function collectMessagingSnapshot() {
-  return {
-    lowBalance: safeString((shopSettingsPage?.querySelector('[data-messaging-field="lowBalance"]') || {}).value, ''),
-    success: safeString((shopSettingsPage?.querySelector('[data-messaging-field="success"]') || {}).value, ''),
-    supportCta: safeString((shopSettingsPage?.querySelector('[data-messaging-field="supportCta"]') || {}).value, ''),
-    supportLink: safeString((shopSettingsPage?.querySelector('[data-messaging-field="supportLink"]') || {}).value, ''),
-    showTutorial: getCheckboxValue(shopShowTutorialToggle, true)
-  };
+function collectShopPackagesByType() {
+  const result = {};
+  if (!shopPackageCards.length) return result;
+  shopPackageCards.forEach((card) => {
+    const pkg = readPackageCard(card);
+    if (!pkg || !pkg.id) return;
+    const type = pkg.type || safeString(card.dataset.shopPackage || 'general', 'general');
+    if (!result[type]) result[type] = [];
+    const pkgCopy = { ...pkg };
+    delete pkgCopy.type;
+    result[type].push(pkgCopy);
+  });
+  return result;
 }
 
 function collectShopSettingsSnapshot() {
@@ -6013,31 +5931,17 @@ function collectShopSettingsSnapshot() {
     lowBalanceThreshold: safeNumber(shopLowBalanceThresholdInput ? shopLowBalanceThresholdInput.value : 0, 0),
     quickTopup: getCheckboxValue(shopQuickTopupToggle),
     quickPurchase: getCheckboxValue(shopQuickPurchaseToggle),
-    dynamicPricing: getCheckboxValue(shopDynamicPricingToggle),
     hero: {
       title: safeString(shopHeroTitleInput ? shopHeroTitleInput.value : '', ''),
       subtitle: safeString(shopHeroSubtitleInput ? shopHeroSubtitleInput.value : '', ''),
       ctaText: safeString(shopHeroCtaInput ? shopHeroCtaInput.value : '', ''),
-      ctaLink: safeString(shopHeroLinkInput ? shopHeroLinkInput.value : '', ''),
-      theme: safeString(shopHeroThemeSelect ? shopHeroThemeSelect.value : 'sky', 'sky') || 'sky',
-      note: safeString(shopHeroNoteInput ? shopHeroNoteInput.value : '', ''),
-      showBalances: getCheckboxValue(shopShowBalancesToggle, true),
-      showTags: getCheckboxValue(shopShowTagsToggle, true)
+      ctaLink: safeString(shopHeroLinkInput ? shopHeroLinkInput.value : '', '')
     },
-    sections: {
-      hero: getCheckboxValue(shopHeroToggle, true),
-      keys: getCheckboxValue(shopKeysToggle, true),
-      wallet: getCheckboxValue(shopWalletToggle, true),
-      vip: getCheckboxValue(shopVipToggle, true),
-      promotions: getCheckboxValue(shopPromotionsToggle, true)
-    },
-    packages: {
-      keys: collectPackageRows('keys'),
-      wallet: collectPackageRows('wallet')
-    },
-    vip: collectVipPlansSnapshot(),
-    promotions: collectPromotionsSnapshot(),
-    messaging: collectMessagingSnapshot()
+    packages: collectShopPackagesByType(),
+    support: {
+      message: safeString(shopSupportMessageInput ? shopSupportMessageInput.value : '', ''),
+      link: safeString(shopSupportLinkInput ? shopSupportLinkInput.value : '', '')
+    }
   };
 }
 
@@ -6110,7 +6014,7 @@ function handleSettingsSave() {
     applySettingsSnapshot(snapshot);
     showToast('تنظیمات ذخیره شد و اعمال شد', 'success');
     markShopUpdated();
-    updateShopMetrics();
+    updateShopSummary();
     try {
       window.dispatchEvent(new CustomEvent('iquiz-admin-settings-updated', { detail: snapshot }));
     } catch (_) {}
@@ -6129,160 +6033,19 @@ if (settingsSaveButton) {
 initializeSettingsFromStorage();
 
 // --------------- SHOP SETTINGS ---------------
-const shopToggleDisableMap = new WeakMap();
-const shopToggleVisibilityMap = new WeakMap();
-const shopState = {
-  enabled: shopGlobalToggle ? shopGlobalToggle.checked : true,
-  initialized: false,
-  lastUpdated: null,
-  metrics: {
-    activeSections: { total: shopSectionToggles.length, active: 0 },
-    packages: { total: shopPackageToggles.length, active: 0 },
-    vipPlans: { total: shopVipToggles.length, active: 0 }
-  }
-};
-
-function parseSelectorList(selectors) {
-  if (typeof selectors !== 'string') return [];
-  return selectors.split(',').map((item) => item.trim()).filter(Boolean);
-}
-
-function getToggleTargets(toggle) {
-  if (!toggle || !toggle.dataset) return [];
-  if (!toggle.__shopToggleTargets) {
-    const selectors = parseSelectorList(toggle.dataset.toggleTarget || '');
-    toggle.__shopToggleTargets = selectors.flatMap((selector) => Array.from(document.querySelectorAll(selector)));
-  }
-  return toggle.__shopToggleTargets;
-}
-
-function updateDisableBehavior(target, toggle, isChecked) {
-  if (!target) return;
-  if (!shopToggleDisableMap.has(target)) {
-    shopToggleDisableMap.set(target, new Set());
-  }
-  const toggles = shopToggleDisableMap.get(target);
-  if (isChecked) {
-    toggles.delete(toggle);
-  } else {
-    toggles.add(toggle);
-  }
-
-  const shouldDisable = toggles.size > 0;
-  if (target.matches('input, select, textarea, button')) {
-    if (!target.dataset.toggleOriginalDisabled) {
-      target.dataset.toggleOriginalDisabled = target.disabled ? 'true' : 'false';
-    }
-    const originalDisabled = target.dataset.toggleOriginalDisabled === 'true';
-    target.disabled = shouldDisable || originalDisabled;
-  } else {
-    const controls = target.querySelectorAll('input, select, textarea, button');
-    controls.forEach((control) => {
-      if (!control.dataset.toggleOriginalDisabled) {
-        control.dataset.toggleOriginalDisabled = control.disabled ? 'true' : 'false';
-      }
-      const originalDisabled = control.dataset.toggleOriginalDisabled === 'true';
-      control.disabled = shouldDisable || originalDisabled;
-    });
-  }
-
-  if (!target.hasAttribute('data-shop-lockable')) {
-    target.classList.toggle('settings-section-disabled', shouldDisable);
-  }
-  if (shouldDisable) {
-    target.setAttribute('aria-disabled', 'true');
-  } else if (!shopToggleDisableMap.get(target)?.size) {
-    target.removeAttribute('aria-disabled');
-  }
-}
-
-function updateVisibilityBehavior(target, toggle, isChecked) {
-  if (!target) return;
-  if (!shopToggleVisibilityMap.has(target)) {
-    shopToggleVisibilityMap.set(target, new Set());
-  }
-  const toggles = shopToggleVisibilityMap.get(target);
-  if (isChecked) {
-    toggles.delete(toggle);
-  } else {
-    toggles.add(toggle);
-  }
-  const hidden = toggles.size > 0;
-  target.classList.toggle('hidden', hidden);
-  target.setAttribute('aria-hidden', hidden ? 'true' : 'false');
-}
-
-function applyToggleTargets(toggle, isChecked) {
-  if (!toggle) return;
-  const behavior = toggle.dataset.toggleBehavior || 'disable';
-  const targets = getToggleTargets(toggle);
-  targets.forEach((target) => {
-    if (behavior === 'visibility') {
-      updateVisibilityBehavior(target, toggle, isChecked);
-    } else {
-      updateDisableBehavior(target, toggle, isChecked);
-    }
-  });
-}
-
-function updateToggleTexts(toggle, isChecked) {
+function syncToggleLabel(toggle) {
   if (!toggle) return;
   const label = toggle.closest('label');
-  if (label) {
-    const labelText = label.querySelector('[data-toggle-text]');
-    if (labelText) {
-      if (!labelText.dataset.toggleOnText) {
-        labelText.dataset.toggleOnText = toggle.dataset.toggleOn || labelText.textContent || 'روشن';
-      }
-      if (!labelText.dataset.toggleOffText) {
-        labelText.dataset.toggleOffText = toggle.dataset.toggleOff || labelText.textContent || 'خاموش';
-      }
-      labelText.textContent = isChecked ? labelText.dataset.toggleOnText : labelText.dataset.toggleOffText;
-    }
+  if (!label) return;
+  const labelText = label.querySelector('[data-toggle-text]');
+  if (!labelText) return;
+  if (!labelText.dataset.toggleOnText) {
+    labelText.dataset.toggleOnText = toggle.dataset.toggleOn || labelText.textContent || 'فعال';
   }
-
-  const labelTargets = parseSelectorList(toggle.dataset.toggleLabelTarget || '');
-  labelTargets.forEach((selector) => {
-    document.querySelectorAll(selector).forEach((target) => {
-      if (!target) return;
-      if (!target.dataset.toggleOriginalText) {
-        target.dataset.toggleOriginalText = target.textContent.trim();
-      }
-      if (!target.dataset.toggleOnText && toggle.dataset.toggleOn) {
-        target.dataset.toggleOnText = toggle.dataset.toggleOn;
-      }
-      if (!target.dataset.toggleOffText && toggle.dataset.toggleOff) {
-        target.dataset.toggleOffText = toggle.dataset.toggleOff;
-      }
-      const onText = target.dataset.toggleOnText || target.dataset.toggleOriginalText;
-      const offText = target.dataset.toggleOffText || target.dataset.toggleOriginalText;
-      target.textContent = isChecked ? onText : offText;
-    });
-  });
-}
-
-function getSectionToggleForElement(element) {
-  if (!element) return null;
-  const section = element.closest('[data-shop-lockable]');
-  if (!section) return null;
-  return section.querySelector('[data-shop-section-toggle]');
-}
-
-function isShopFeatureActive(element) {
-  if (!shopState.enabled) return false;
-  const sectionToggle = getSectionToggleForElement(element);
-  if (sectionToggle && !sectionToggle.checked) return false;
-  return true;
-}
-
-function updateSectionVisualState() {
-  if (!shopLockableSections.length) return;
-  shopLockableSections.forEach((section) => {
-    const sectionToggle = section.querySelector('[data-shop-section-toggle]');
-    const sectionActive = shopState.enabled && (!sectionToggle || sectionToggle.checked);
-    section.classList.toggle('settings-section-disabled', !sectionActive);
-    section.setAttribute('aria-disabled', sectionActive ? 'false' : 'true');
-  });
+  if (!labelText.dataset.toggleOffText) {
+    labelText.dataset.toggleOffText = toggle.dataset.toggleOff || labelText.textContent || 'غیرفعال';
+  }
+  labelText.textContent = toggle.checked ? labelText.dataset.toggleOnText : labelText.dataset.toggleOffText;
 }
 
 function updateShopStatus(isEnabled) {
@@ -6295,97 +6058,66 @@ function updateShopStatus(isEnabled) {
     }
   }
   if (shopStatusLabel) {
-    if (!shopStatusLabel.dataset.toggleOriginalText) {
-      shopStatusLabel.dataset.toggleOriginalText = shopStatusLabel.textContent.trim();
-    }
     shopStatusLabel.textContent = isEnabled ? 'فروشگاه فعال است' : 'فروشگاه غیرفعال است';
   }
-}
-
-function formatRatio(active, total) {
-  if (!Number.isFinite(total) || total <= 0) {
-    return formatNumberFa(active);
+  if (shopGlobalStatusLabel) {
+    shopGlobalStatusLabel.textContent = isEnabled ? 'فعال' : 'غیرفعال';
+    shopGlobalStatusLabel.classList.toggle('text-emerald-300', isEnabled);
+    shopGlobalStatusLabel.classList.toggle('text-rose-300', !isEnabled);
   }
-  return `${formatNumberFa(active)} / ${formatNumberFa(total)}`;
-}
-
-function isSectionEnabled(toggle) {
-  if (!shopState.enabled) return false;
-  if (!toggle) return true;
-  return toggle.checked;
-}
-
-function updateShopMetrics() {
-  const sectionsTotal = shopSectionToggles.length;
-  const sectionsActive = shopState.enabled
-    ? shopSectionToggles.filter((toggle) => toggle.checked).length
-    : 0;
-  shopState.metrics.activeSections = { total: sectionsTotal, active: sectionsActive };
-  if (shopMetricElements.activeSections) {
-    shopMetricElements.activeSections.textContent = formatRatio(sectionsActive, sectionsTotal);
-  }
-
-  const packagesTotal = shopPackageToggles.length;
-  const packagesActive = shopState.enabled
-    ? shopPackageToggles.filter((toggle) => toggle.checked && isShopFeatureActive(toggle)).length
-    : 0;
-  shopState.metrics.packages = { total: packagesTotal, active: packagesActive };
-  if (shopMetricElements.packages) {
-    shopMetricElements.packages.textContent = formatRatio(packagesActive, packagesTotal);
-  }
-
-  const vipTotal = shopVipToggles.length;
-  const vipActive = shopState.enabled && isSectionEnabled(shopVipToggle)
-    ? shopVipToggles.filter((toggle) => toggle.checked).length
-    : 0;
-  shopState.metrics.vipPlans = { total: vipTotal, active: vipActive };
-  if (shopMetricElements.vipPlans) {
-    shopMetricElements.vipPlans.textContent = formatRatio(vipActive, vipTotal);
+  if (shopSummaryElements.status) {
+    shopSummaryElements.status.textContent = isEnabled ? 'فعال' : 'غیرفعال';
   }
 }
 
-function updateHeroTheme() {
-  if (!shopHeroPreview || !shopHeroThemeSelect) return;
-  const theme = shopHeroThemeSelect.value || 'sky';
-  shopHeroPreview.dataset.theme = theme;
+function updateHeroPreview() {
+  const title = safeString(shopHeroTitleInput ? shopHeroTitleInput.value : '', '');
+  const subtitle = safeString(shopHeroSubtitleInput ? shopHeroSubtitleInput.value : '', '');
+  const ctaText = safeString(shopHeroCtaInput ? shopHeroCtaInput.value : '', '');
+  const ctaLink = safeString(shopHeroLinkInput ? shopHeroLinkInput.value : '', '');
+  const ctaEnabled = getCheckboxValue(shopQuickTopupToggle, true);
+
+  if (shopHeroPreviewTitle) {
+    shopHeroPreviewTitle.textContent = title || 'عنوان فروشگاه شما';
+    shopHeroPreviewTitle.classList.toggle('opacity-70', !title);
+  }
+  if (shopHeroPreviewSubtitle) {
+    shopHeroPreviewSubtitle.textContent = subtitle || 'توضیح کوتاه را اینجا بنویسید.';
+    shopHeroPreviewSubtitle.classList.toggle('opacity-70', !subtitle);
+  }
+  if (shopPreviewCtaLabel) {
+    shopPreviewCtaLabel.textContent = ctaText || 'ورود به فروشگاه';
+  }
+  if (shopPreviewCta) {
+    shopPreviewCta.href = ctaLink || '#';
+    shopPreviewCta.classList.toggle('opacity-60', !ctaEnabled);
+    shopPreviewCta.classList.toggle('pointer-events-none', !ctaEnabled);
+  }
+  if (shopPreviewHelper) {
+    shopPreviewHelper.textContent = ctaEnabled ? 'CTA برای هدایت سریع کاربران' : 'دکمه CTA غیرفعال شده است';
+  }
 }
 
-function updateHeroLink() {
-  if (!shopPreviewCta) return;
-  const linkValue = shopHeroLinkInput ? shopHeroLinkInput.value.trim() : '';
-  shopPreviewCta.setAttribute('href', linkValue || '#');
-}
+function updateShopSummary() {
+  const totalPackages = shopPackageCards.length;
+  const activePackages = shopPackageCards.filter((card) => {
+    const toggle = card.querySelector('[data-shop-package-active]');
+    return getCheckboxValue(toggle, true);
+  }).length;
 
-function updateBoundTargets(input) {
-  if (!input) return;
-  const selectors = parseSelectorList(input.dataset.bindTarget || '');
-  const value = typeof input.value === 'string' ? input.value : String(input.value ?? '');
-  selectors.forEach((selector) => {
-    document.querySelectorAll(selector).forEach((target) => {
-      if (!target) return;
-      if (!target.dataset.shopBindFallback) {
-        target.dataset.shopBindFallback = target.textContent;
-      }
-      const trimmed = value.trim();
-      if (target.id === 'shop-preview-note') {
-        const fallback = target.dataset.shopBindFallback || '';
-        if (trimmed) {
-          target.textContent = trimmed;
-          target.classList.remove('hidden', 'opacity-50');
-          target.setAttribute('aria-hidden', 'false');
-        } else {
-          target.textContent = fallback;
-          target.classList.add('hidden');
-          target.classList.add('opacity-50');
-          target.setAttribute('aria-hidden', 'true');
-        }
-      } else {
-        const placeholder = target.dataset.shopBindPlaceholder || '—';
-        target.textContent = trimmed || placeholder;
-        target.classList.toggle('opacity-50', trimmed.length === 0);
-      }
-    });
-  });
+  if (shopSummaryElements.packages) {
+    shopSummaryElements.packages.textContent = totalPackages
+      ? `${formatNumberFa(activePackages)} از ${formatNumberFa(totalPackages)} فعال`
+      : 'بدون پکیج';
+  }
+
+  const shortcutToggles = [shopQuickTopupToggle, shopQuickPurchaseToggle].filter(Boolean);
+  const shortcutsActive = shortcutToggles.filter((toggle) => getCheckboxValue(toggle, true)).length;
+  if (shopSummaryElements.shortcuts) {
+    shopSummaryElements.shortcuts.textContent = shortcutToggles.length
+      ? `${formatNumberFa(shortcutsActive)} / ${formatNumberFa(shortcutToggles.length)} فعال`
+      : '—';
+  }
 }
 
 function markShopUpdated() {
@@ -6394,129 +6126,87 @@ function markShopUpdated() {
   shopState.lastUpdated = now;
   try {
     const formatter = new Intl.DateTimeFormat('fa-IR', { hour: '2-digit', minute: '2-digit' });
-    const timeText = formatter.format(now);
-    shopLastUpdateEl.textContent = `لحظاتی پیش (${timeText})`;
-  } catch (error) {
+    shopLastUpdateEl.textContent = `لحظاتی پیش (${formatter.format(now)})`;
+  } catch (_) {
     shopLastUpdateEl.textContent = 'لحظاتی پیش';
   }
-}
-
-function initializeShopToggle(toggle) {
-  if (!toggle) return;
-  const isChecked = toggle.checked;
-  toggle.dataset.toggleAppliedState = isChecked ? 'on' : 'off';
-  applyToggleTargets(toggle, isChecked);
-  updateToggleTexts(toggle, isChecked);
-}
-
-function handleShopToggleChange(toggle) {
-  if (!toggle) return;
-  const isChecked = toggle.checked;
-  const previousState = toggle.dataset.toggleAppliedState === 'on';
-  if (previousState === isChecked && shopState.initialized) {
-    updateToggleTexts(toggle, isChecked);
-    return;
-  }
-  toggle.dataset.toggleAppliedState = isChecked ? 'on' : 'off';
-  applyToggleTargets(toggle, isChecked);
-  updateToggleTexts(toggle, isChecked);
-
-  if (toggle === shopGlobalToggle) {
-    shopState.enabled = isChecked;
-    updateShopStatus(isChecked);
-  }
-
-  updateSectionVisualState();
-  updateShopMetrics();
-
-  if (shopState.initialized) {
-    markShopUpdated();
-  }
-}
-
-function handleShopInputEvent(event) {
-  const target = event.target;
-  if (!target || !shopState.initialized) return;
-  if (target.matches('input[type="checkbox"], input[type="radio"]')) return;
-  if (target.hasAttribute('data-bind-target')) return;
-  markShopUpdated();
 }
 
 function setupShopControls() {
   if (!shopSettingsPage) return;
 
-  const syncAdvancedVisibility = (expanded) => {
-    shopAdvancedSections.forEach((section) => {
-      section.classList.toggle('hidden', !expanded);
+  const registerToggle = (toggle) => {
+    if (!toggle) return;
+    syncToggleLabel(toggle);
+    toggle.addEventListener('change', () => {
+      if (toggle === shopGlobalToggle) {
+        updateShopStatus(toggle.checked);
+      }
+      if (toggle === shopQuickTopupToggle) {
+        updateHeroPreview();
+      }
+      updateShopSummary();
+      if (shopState.initialized) {
+        markShopUpdated();
+      }
     });
-    if (shopAdvancedToggleBtn) {
-      shopAdvancedToggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    }
-    if (shopAdvancedToggleLabel) {
-      shopAdvancedToggleLabel.textContent = expanded
-        ? 'پنهان‌سازی تنظیمات پیشرفته'
-        : 'نمایش تنظیمات پیشرفته';
-    }
   };
 
-  let advancedExpanded = false;
-  syncAdvancedVisibility(advancedExpanded);
+  [shopGlobalToggle, shopQuickTopupToggle, shopQuickPurchaseToggle].forEach(registerToggle);
 
-  if (shopAdvancedToggleBtn) {
-    shopAdvancedToggleBtn.addEventListener('click', () => {
-      advancedExpanded = !advancedExpanded;
-      syncAdvancedVisibility(advancedExpanded);
-    });
-  }
-
-  const toggles = Array.from(shopSettingsPage.querySelectorAll('input[type="checkbox"]'));
-  toggles.forEach((toggle) => {
-    initializeShopToggle(toggle);
-    toggle.addEventListener('change', () => handleShopToggleChange(toggle));
-  });
-
-  shopBoundInputs.forEach((input) => {
-    updateBoundTargets(input);
-    input.addEventListener('input', (event) => {
-      updateBoundTargets(event.target);
+  const heroInputs = [shopHeroTitleInput, shopHeroSubtitleInput, shopHeroCtaInput, shopHeroLinkInput];
+  heroInputs.forEach((input) => {
+    if (!input) return;
+    input.addEventListener('input', () => {
+      updateHeroPreview();
       if (shopState.initialized) {
         markShopUpdated();
       }
     });
   });
 
-  if (shopHeroThemeSelect) {
-    updateHeroTheme();
-    shopHeroThemeSelect.addEventListener('change', () => {
-      updateHeroTheme();
+  const supportInputs = [shopSupportMessageInput, shopSupportLinkInput, shopPricingCurrencySelect, shopLowBalanceThresholdInput];
+  supportInputs.forEach((input) => {
+    if (!input) return;
+    const eventName = input.tagName === 'SELECT' ? 'change' : 'input';
+    input.addEventListener(eventName, () => {
+      if (input === shopPricingCurrencySelect || input === shopLowBalanceThresholdInput) {
+        updateShopSummary();
+      }
       if (shopState.initialized) {
         markShopUpdated();
       }
     });
-  }
-
-  if (shopHeroLinkInput) {
-    updateHeroLink();
-    shopHeroLinkInput.addEventListener('input', () => {
-      updateHeroLink();
-      if (shopState.initialized) {
-        markShopUpdated();
-      }
-    });
-  }
-
-  shopSettingsPage.addEventListener('input', handleShopInputEvent);
-  shopSettingsPage.addEventListener('change', (event) => {
-    const target = event.target;
-    if (!target || !shopState.initialized) return;
-    if (target.matches('select') && target !== shopHeroThemeSelect) {
-      markShopUpdated();
-    }
   });
 
-  updateShopStatus(shopState.enabled);
-  updateSectionVisualState();
-  updateShopMetrics();
+  shopPackageCards.forEach((card) => {
+    const toggle = card.querySelector('[data-shop-package-active]');
+    syncToggleLabel(toggle);
+    const nameInput = card.querySelector('[data-package-field="displayName"]');
+    const inputs = card.querySelectorAll('input, textarea');
+    inputs.forEach((input) => {
+      const eventName = input.type === 'checkbox' ? 'change' : 'input';
+      input.addEventListener(eventName, () => {
+        if (input === toggle) {
+          syncToggleLabel(toggle);
+          updateShopSummary();
+        }
+        if (input === nameInput) {
+          const nameEl = card.querySelector('[data-package-name]');
+          if (nameEl) {
+            nameEl.textContent = safeString(nameInput.value, '') || '—';
+          }
+        }
+        if (shopState.initialized) {
+          markShopUpdated();
+        }
+      });
+    });
+  });
+
+  updateShopStatus(getCheckboxValue(shopGlobalToggle, true));
+  updateHeroPreview();
+  updateShopSummary();
 
   shopState.initialized = true;
 }


### PR DESCRIPTION
## Summary
- redesign the admin shop settings card with streamlined status tiles, clear toggles, a refreshed hero preview, and concise package/support editors.
- refactor the shop settings script to match the simplified layout, keeping previews, summaries, and data collection in sync.

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d525e3ed0c8326b450de88dba25f64