### PR TITLE
feat: add admin review mode for questions

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -959,6 +959,16 @@
       background: linear-gradient(135deg, rgba(129,140,248,0.16), rgba(165,180,252,0.1));
       color: #a5b4fc;
     }
+    .meta-chip.moderation-active {
+      border-color: rgba(34, 197, 94, 0.35);
+      background: linear-gradient(135deg, rgba(34,197,94,0.18), rgba(22,163,74,0.12));
+      color: #4ade80;
+    }
+    .meta-chip.moderation-inactive {
+      border-color: rgba(248, 113, 113, 0.4);
+      background: linear-gradient(135deg, rgba(248,113,113,0.2), rgba(220,38,38,0.12));
+      color: #f87171;
+    }
     .meta-chip.author {
       border-color: rgba(251, 191, 36, 0.35);
       background: linear-gradient(135deg, rgba(251,191,36,0.18), rgba(253,224,71,0.12));
@@ -2327,12 +2337,12 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm mb-1">فیلتر تایید</label>
+              <label class="block text-sm mb-1">حالت بازبینی</label>
               <label class="toggle text-xs">
                 <input type="checkbox" id="filter-approved-only">
-                <span class="toggle-label">فقط تایید شده</span>
+                <span class="toggle-label">نمایش همه (تایید نشده و غیرفعال)</span>
               </label>
-              <p class="text-[11px] text-white/50 mt-2" id="filter-approved-helper">غیرفعال کردن این گزینه، سوالات تایید نشده را نیز نمایش می‌دهد.</p>
+              <p class="text-[11px] text-white/50 mt-2" id="filter-approved-helper">با فعال شدن حالت بازبینی، تمام سوالات از جمله موارد تایید نشده یا غیرفعال نمایش داده می‌شوند.</p>
             </div>
           </div>
         </div>

--- a/server/SERVER_NOTES.md
+++ b/server/SERVER_NOTES.md
@@ -1,0 +1,6 @@
+# Questions API review mode
+
+- `GET /api/questions` and `GET /api/questions/search` accept `reviewMode=all`.
+- The caller must be authenticated as an admin; otherwise the server responds with `403`.
+- When `reviewMode=all` is active the `status/active` gate is removed but structural validation still filters broken records. Each item includes a `moderation` payload with `{ status, active }` for UI badges.
+- Set `ALLOW_REVIEW_MODE_ALL=false` in the environment to disable the override entirely (default is `true`).

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -55,6 +55,8 @@ const openAiApiKey = process.env.OPENAI_API_KEY || '';
 const openAiOrganization = process.env.OPENAI_ORG || process.env.OPENAI_ORGANIZATION || '';
 const openAiProject = process.env.OPENAI_PROJECT || '';
 
+const allowReviewModeAll = parseBoolean(process.env.ALLOW_REVIEW_MODE_ALL, true);
+
 const env = {
   nodeEnv,
   isProduction: nodeEnv === 'production',
@@ -79,6 +81,9 @@ const env = {
       organization: openAiOrganization,
       project: openAiProject
     }
+  },
+  features: {
+    allowReviewModeAll
   }
 };
 

--- a/server/src/routes/questions.routes.js
+++ b/server/src/routes/questions.routes.js
@@ -4,6 +4,7 @@ const ctrl = require('../controllers/questions.controller');
 
 router.use(protect, adminOnly);
 router.get('/duplicates', ctrl.listDuplicates);
+router.get('/search', ctrl.search);
 router.get('/', ctrl.list);
 router.get('/stats/summary', ctrl.statsSummary);
 router.post('/', ctrl.create);

--- a/server/test/questionsController.test.js
+++ b/server/test/questionsController.test.js
@@ -1,0 +1,203 @@
+const test = require('node:test');
+const assert = require('assert');
+
+process.env.ALLOW_REVIEW_MODE_ALL = process.env.ALLOW_REVIEW_MODE_ALL ?? 'true';
+
+const questionsController = require('../src/controllers/questions.controller');
+const Question = require('../src/models/Question');
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function stubQuestionModel({ docs = [], total = docs.length, pendingTotal = 0, aggregateResult = [] } = {}) {
+  const originalFind = Question.find;
+  const originalCountDocuments = Question.countDocuments;
+  const originalAggregate = Question.aggregate;
+
+  let capturedFindWhere = null;
+  const capturedCounts = [];
+
+  Question.find = (where = {}) => {
+    capturedFindWhere = where;
+    const chain = {
+      populate() { return chain; },
+      sort() { return chain; },
+      skip() { return chain; },
+      limit() { return chain; },
+      lean() { return Promise.resolve(docs); }
+    };
+    return chain;
+  };
+
+  Question.countDocuments = (where = {}) => {
+    capturedCounts.push(where);
+    if (where && where.status === 'pending') {
+      return Promise.resolve(pendingTotal);
+    }
+    return Promise.resolve(total);
+  };
+
+  Question.aggregate = () => Promise.resolve(aggregateResult);
+
+  return {
+    getFindWhere() {
+      return capturedFindWhere;
+    },
+    getCountArgs() {
+      return capturedCounts.slice();
+    },
+    restore() {
+      Question.find = originalFind;
+      Question.countDocuments = originalCountDocuments;
+      Question.aggregate = originalAggregate;
+    }
+  };
+}
+
+test('list applies approved filter by default', async () => {
+  const docs = [
+    {
+      _id: 'q1',
+      text: 'نمونه سوال تاریخ ایران',
+      options: ['گزینه ۱', 'گزینه ۲', 'گزینه ۳', 'گزینه ۴'],
+      correctIdx: 1,
+      status: 'approved',
+      active: true
+    }
+  ];
+  const stub = stubQuestionModel({ docs });
+
+  const req = { query: {}, user: { role: 'admin' } };
+  const res = createMockRes();
+
+  try {
+    await questionsController.list(req, res, () => { throw new Error('next should not be called'); });
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body?.ok);
+    const where = stub.getFindWhere();
+    assert.ok(where);
+    assert.deepStrictEqual(where.isApproved, { $ne: false });
+    assert.ok(Array.isArray(res.body?.data));
+    assert.strictEqual(res.body.data.length, 1);
+    assert.deepStrictEqual(res.body.data[0].moderation, { status: 'approved', active: true });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('reviewMode=all returns mixed statuses without approval constraint', async () => {
+  const docs = [
+    {
+      _id: 'q1',
+      text: 'سوال تایید شده',
+      options: ['الف', 'ب', 'پ', 'ت'],
+      correctIdx: 0,
+      status: 'approved',
+      active: true
+    },
+    {
+      _id: 'q2',
+      text: 'سوال منتظر تایید',
+      options: ['۱', '۲', '۳', '۴'],
+      correctIdx: 2,
+      status: 'pending',
+      active: false
+    }
+  ];
+  const stub = stubQuestionModel({ docs });
+
+  const req = { query: { reviewMode: 'all' }, user: { role: 'admin' } };
+  const res = createMockRes();
+
+  try {
+    await questionsController.list(req, res, () => { throw new Error('next should not be called'); });
+    assert.strictEqual(res.statusCode, 200);
+    const where = stub.getFindWhere();
+    assert.ok(where);
+    assert.ok(!('isApproved' in where));
+    assert.strictEqual(res.body.data.length, 2);
+    const statuses = res.body.data.map((item) => item?.moderation?.status).sort();
+    assert.deepStrictEqual(statuses, ['approved', 'pending']);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('reviewMode=all is forbidden for non-admin users', async () => {
+  const stub = stubQuestionModel({ docs: [] });
+
+  const req = { query: { reviewMode: 'all' }, user: { role: 'editor' } };
+  const res = createMockRes();
+
+  try {
+    await questionsController.list(req, res, () => { throw new Error('next should not be called'); });
+    assert.strictEqual(res.statusCode, 403);
+    assert.deepStrictEqual(res.body, { ok: false, message: 'Forbidden' });
+    assert.strictEqual(stub.getFindWhere(), null);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('list filters out structurally invalid questions', async () => {
+  const docs = [
+    {
+      _id: 'valid',
+      text: 'پایتخت ایران چیست؟',
+      options: ['تهران', 'اصفهان', 'شیراز', 'تبریز'],
+      correctIdx: 0,
+      status: 'approved',
+      active: true
+    },
+    {
+      _id: 'invalid-text',
+      text: '   ',
+      options: ['گزینه', 'دیگر'],
+      correctIdx: 0,
+      status: 'approved',
+      active: true
+    },
+    {
+      _id: 'invalid-options',
+      text: 'سوال ناقص',
+      options: ['فقط یک گزینه'],
+      correctIdx: 0,
+      status: 'approved',
+      active: true
+    },
+    {
+      _id: 'invalid-index',
+      text: 'سوال با شاخص نادرست',
+      options: ['گزینه ۱', 'گزینه ۲', 'گزینه ۳', 'گزینه ۴'],
+      correctIdx: 7,
+      status: 'approved',
+      active: true
+    }
+  ];
+  const stub = stubQuestionModel({ docs });
+
+  const req = { query: { reviewMode: 'all' }, user: { role: 'admin' } };
+  const res = createMockRes();
+
+  try {
+    await questionsController.list(req, res, () => { throw new Error('next should not be called'); });
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(Array.isArray(res.body.data));
+    assert.strictEqual(res.body.data.length, 1);
+    assert.strictEqual(res.body.data[0]._id, 'valid');
+  } finally {
+    stub.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- add an admin review-mode toggle in the dashboard with new moderation badges for status and activity
- allow the questions API to accept `reviewMode=all`, return moderation metadata, and document the feature flag
- cover the new behaviour with controller unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5397b1fc08326848e5394601aa757