### PR TITLE
Prevent key count from dropping below zero

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -16,7 +16,8 @@ import {
   isUserInGroup,
   stringToSeed,
   buildRosterEntry,
-  seededFloat
+  seededFloat,
+  spendKeys
 } from '../state/state.js';
 import { Server } from '../state/server.js';
 import {
@@ -1684,11 +1685,11 @@ function startQuizTimerCountdown(){
       SFX.correct(); vibrate(30);
     } else {
       State.quiz.correctStreak = 0;
-      State.lives -= 1;
+      const remainingKeys = spendKeys(1);
       // Use a life from the limit
       useGameResource('lives');
       SFX.wrong(); vibrate([10,30,10]);
-      if(State.lives<=0) shouldEnd = true;
+      if(remainingKeys<=0) shouldEnd = true;
     }
 
     State.quiz.results.push({ q:q.q, ok, correct: q.c[correct], you: idx>=0 && q.c[idx] != null ? q.c[idx] : '—' });
@@ -5100,7 +5101,7 @@ function leaveGroup(groupId) {
       toast('نیازی به ریست نیست');
       return;
     }
-    State.lives -= 1;
+    spendKeys(1);
     renderTopBars();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -5122,7 +5123,7 @@ function leaveGroup(groupId) {
       toast('نیازی به ریست نیست');
       return;
     }
-    State.lives -= 1;
+    spendKeys(1);
     renderTopBars();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -5144,7 +5145,7 @@ function leaveGroup(groupId) {
       toast('نیازی به ریست نیست');
       return;
     }
-    State.lives -= 1;
+    spendKeys(1);
     renderTopBars();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -5172,7 +5173,7 @@ function leaveGroup(groupId) {
       });
       const data = await res.json();
       if (res.ok && data?.success) {
-        State.lives -= 1;
+        spendKeys(1);
         renderTopBars();
         const today = new Date();
         today.setHours(0, 0, 0, 0);

--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -1,7 +1,7 @@
 import { $, $$ } from '../../utils/dom.js';
 import { faNum } from '../../utils/format.js';
 import { toast, SFX } from '../../utils/feedback.js';
-import { State } from '../../state/state.js';
+import { State, spendKeys } from '../../state/state.js';
 import { saveState } from '../../state/persistence.js';
 
 const LIFELINE_COST = 3;
@@ -81,7 +81,7 @@ export function spendLifelineCost() {
     animateKeyChip();
     return false;
   }
-  State.lives -= LIFELINE_COST;
+  spendKeys(LIFELINE_COST);
   callDependency('renderTopBars');
   saveState();
   animateKeyChip();

--- a/Iquiz-assets/src/state/state.js
+++ b/Iquiz-assets/src/state/state.js
@@ -105,6 +105,18 @@ const DEFAULT_DUEL_INVITES = (() => {
   ];
 })();
 
+function normalizeKeyCount(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.floor(numeric));
+}
+
+function normalizeKeyAdjustment(amount) {
+  const numeric = Number(amount);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.floor(numeric));
+}
+
 function cloneDefaultRoster(groupId){
   return (DEFAULT_GROUP_ROSTERS[groupId] || []).map(player => ({ ...player }));
 }
@@ -274,6 +286,27 @@ const State = {
   }
 };
 
+const INTERNAL_KEY_STATE = { value: normalizeKeyCount(State.lives) };
+
+Object.defineProperty(State, 'lives', {
+  get() {
+    return INTERNAL_KEY_STATE.value;
+  },
+  set(value) {
+    INTERNAL_KEY_STATE.value = normalizeKeyCount(value);
+  },
+  enumerable: true,
+  configurable: false,
+});
+
+function spendKeys(amount = 1) {
+  const deduction = normalizeKeyAdjustment(amount);
+  if (deduction <= 0) return State.lives;
+  const remaining = INTERNAL_KEY_STATE.value - deduction;
+  State.lives = remaining;
+  return State.lives;
+}
+
 function ensureGroupRosters(){
   if (!Array.isArray(State.groups)) State.groups = [];
   State.groups.forEach(group => {
@@ -325,5 +358,6 @@ export {
   stringToSeed,
   buildRosterEntry,
   seededFloat,
+  spendKeys,
   DUEL_INVITE_TIMEOUT_MS
 };


### PR DESCRIPTION
## Summary
- clamp the quiz state key counter through an accessor and expose a spendKeys helper
- update quiz lifelines and limit reset flows to deduct keys through the helper so totals never go negative

## Testing
- npm install *(fails: 403 Forbidden fetching openai package)*

------
https://chatgpt.com/codex/tasks/task_e_68d53ebf18248326b7d71746f6dcd066