### PR TITLE
Adjust daily quiz and duel limits

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -178,7 +178,7 @@
                 <i class="fas fa-gamepad text-purple-300"></i>
                 <span>کوییز روزانه</span>
               </div>
-              <span class="text-sm"><span id="matches-used">0</span>/<span id="matches-limit">5</span></span>
+              <span class="text-sm"><span id="matches-used">0</span>/<span id="matches-limit">3</span></span>
             </div>
             <div class="limit-bar">
               <div id="matches-progress" class="limit-progress" style="width:0%"></div>
@@ -197,7 +197,7 @@
                 <i class="fas fa-hand-fist text-rose-400"></i>
                 <span>نبرد تن به تن</span>
               </div>
-              <span class="text-sm"><span id="duels-used">0</span>/<span id="duels-limit">3</span></span>
+              <span class="text-sm"><span id="duels-used">0</span>/<span id="duels-limit">1</span></span>
             </div>
             <div class="limit-bar">
               <div id="duels-progress" class="limit-progress" style="width:0%"></div>

--- a/Iquiz-assets/src/config/remote-config.js
+++ b/Iquiz-assets/src/config/remote-config.js
@@ -44,8 +44,8 @@ export const RemoteConfig = {
   },
 
   gameLimits: {
-    matches: { daily: 5, vipMultiplier: 2, recoveryTime: 2 * 60 * 60 * 1000 },
-    duels:   { daily: 3, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
+    matches: { daily: 3, vipMultiplier: 2, recoveryTime: 2 * 60 * 60 * 1000 },
+    duels:   { daily: 1, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
     lives:   { daily: 3, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
     groupBattles: { daily: 2, vipMultiplier: 2, recoveryTime: 60 * 60 * 1000 },
     energy:  { daily: 10, vipMultiplier: 2, recoveryTime: 15 * 60 * 1000 }

--- a/server/src/services/publicContent.js
+++ b/server/src/services/publicContent.js
@@ -400,8 +400,8 @@ const DEFAULT_REMOTE_CONFIG = {
     B: { ads: { freqCaps: { interstitialPerSession: 1 } } }
   },
   gameLimits: {
-    matches: { daily: 5, vipMultiplier: 2, recoveryTime: 2 * 60 * 60 * 1000 },
-    duels: { daily: 3, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
+    matches: { daily: 3, vipMultiplier: 2, recoveryTime: 2 * 60 * 60 * 1000 },
+    duels: { daily: 1, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
     lives: { daily: 3, vipMultiplier: 2, recoveryTime: 30 * 60 * 1000 },
     groupBattles: { daily: 2, vipMultiplier: 2, recoveryTime: 60 * 60 * 1000 },
     energy: { daily: 10, vipMultiplier: 2, recoveryTime: 15 * 60 * 1000 }


### PR DESCRIPTION
## Summary
- reduce the default daily match limit to three quizzes
- lower the daily duel limit to one battle across client and server configs
- sync the dashboard placeholder values with the new limits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d545eba7808326930bcee6fc751a4e