### PR TITLE
Remove profile image upload option

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1715,8 +1715,6 @@
         </div>
         <label class="block text-sm opacity-90">گروه شما</label>
         <div id="lbl-group" class="w-full p-3 rounded-xl bg-white/10 border border-white/20"></div>
-        <label class="block text-sm opacity-90">عکس پروفایل</label>
-        <input id="inp-avatar" type="file" accept="image/*" class="w-full p-3 rounded-xl bg-white/10 border border-white/20">
       </div>
       <div class="divider"></div>
       <button id="btn-save-profile" class="btn btn-primary">ذخیره</button>

--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -3210,7 +3210,6 @@ async function startPurchaseCoins(pkgId){
     sel.disabled = true;
     const currentGroupName = getUserGroup()?.name || State.user.group || '—';
     $('#lbl-group').textContent = currentGroupName || '—';
-    $('#inp-avatar').value = '';
     openModal('#modal-profile');
   });
   $('[data-close="#modal-profile"]')?.addEventListener('click', ()=>closeModal('#modal-profile'));
@@ -3220,22 +3219,11 @@ async function startPurchaseCoins(pkgId){
 
     // استان قابل تغییر نیست، بنابراین مقدار آن ذخیره نمی‌شود
 
-    const file = $('#inp-avatar').files[0];
-    if(file){
-      const reader = new FileReader();
-      reader.onload = () => { State.user.avatar = reader.result; finish(); };
-      reader.readAsDataURL(file);
-    } else {
-      finish();
-    }
-
-    function finish(){
-      saveState();
-      renderHeader();
-      renderDashboard();
-      closeModal('#modal-profile');
-      toast('ذخیره شد ✅');
-    }
+    saveState();
+    renderHeader();
+    renderDashboard();
+    closeModal('#modal-profile');
+    toast('ذخیره شد ✅');
   });
   $('#btn-confirm-province')?.addEventListener('click', () => {
     const p = $('#first-province').value;


### PR DESCRIPTION
## Summary
- remove the profile image upload field from the profile editing modal
- simplify the profile save handler to drop file input handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5468127788326b42be65afcd70c7b