### PR TITLE
Persist duel friend additions after battles

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -17,7 +17,8 @@ import {
   stringToSeed,
   buildRosterEntry,
   seededFloat,
-  spendKeys
+  spendKeys,
+  DEFAULT_DUEL_FRIENDS
 } from '../state/state.js';
 import { Server } from '../state/server.js';
 import {
@@ -3285,12 +3286,8 @@ async function startPurchaseCoins(pkgId){
   });
   
   // Duel Friends list
-  const duelFriends = [
-    { id: 1, name: 'علی رضایی', score: 12450, avatar: 'https://i.pravatar.cc/60?img=3' },
-    { id: 2, name: 'سارا محمدی', score: 9800, avatar: 'https://i.pravatar.cc/60?img=5' },
-    { id: 3, name: 'رضا قاسمی', score: 15200, avatar: 'https://i.pravatar.cc/60?img=8' },
-    { id: 4, name: 'مریم احمدی', score: 7650, avatar: 'https://i.pravatar.cc/60?img=11' }
-  ];
+  const duelFriends = normalizeDuelFriendsList(State.duelFriends);
+  State.duelFriends = duelFriends;
 
   const randomPool = [
     { id: 5, name: 'حسین کریمی', score: 13200, avatar: 'https://i.pravatar.cc/60?img=12' },
@@ -3645,6 +3642,39 @@ async function startPurchaseCoins(pkgId){
     return normalized;
   }
 
+  function normalizeDuelFriendsList(list){
+    const base = Array.isArray(list) ? list : [];
+    const normalized = [];
+    const seenNames = new Set();
+    const usedIds = new Set();
+    for (const friend of base) {
+      if (!friend || typeof friend !== 'object') continue;
+      const name = typeof friend.name === 'string' ? friend.name.trim() : '';
+      if (!name || seenNames.has(name)) continue;
+      let id = Number(friend.id);
+      if (!Number.isFinite(id) || id <= 0) id = null;
+      const scoreVal = Number(friend.score);
+      const score = Number.isFinite(scoreVal) && scoreVal > 0 ? Math.round(scoreVal) : suggestScoreFromState();
+      const avatar = typeof friend.avatar === 'string' && friend.avatar.trim()
+        ? friend.avatar
+        : generateAvatarFromName(name);
+      normalized.push({ id, name, score, avatar });
+      seenNames.add(name);
+    }
+    if (!normalized.length) {
+      return DEFAULT_DUEL_FRIENDS.map(friend => ({ ...friend }));
+    }
+    normalized.forEach((friend, index) => {
+      let id = Number(friend.id);
+      if (!Number.isFinite(id) || id <= 0 || usedIds.has(id)) {
+        id = index + 1;
+      }
+      usedIds.add(id);
+      friend.id = id;
+    });
+    return normalized.slice(0, 20);
+  }
+
   function hideDuelAddFriendCTA(){
     const container = $('#duel-add-friend');
     const nameEl = $('#duel-add-friend-name');
@@ -3704,6 +3734,7 @@ async function startPurchaseCoins(pkgId){
     };
     duelFriends.unshift(entry);
     renderDuelFriends();
+    saveState();
     toast(`${entry.name} به لیست حریف‌ها اضافه شد ✅`);
   }
 
@@ -3760,6 +3791,7 @@ async function startPurchaseCoins(pkgId){
         const [item] = duelFriends.splice(idx,1);
         duelFriends.unshift(item);
         renderDuelFriends();
+        saveState();
       }
     }
   }

--- a/Iquiz-assets/src/state/persistence.js
+++ b/Iquiz-assets/src/state/persistence.js
@@ -1,4 +1,4 @@
-import { State, STORAGE_KEY, ensureGroupRosters, DUEL_INVITE_TIMEOUT_MS } from './state.js';
+import { State, STORAGE_KEY, ensureGroupRosters, DUEL_INVITE_TIMEOUT_MS, DEFAULT_DUEL_FRIENDS } from './state.js';
 import { Server } from './server.js';
 
 const SERVER_STORAGE_KEY = 'server_state';
@@ -86,6 +86,24 @@ function loadState(){
   }
   if (!Array.isArray(State.duelHistory)) State.duelHistory = [];
   State.duelHistory = State.duelHistory.slice(0, 20);
+  if (!Array.isArray(State.duelFriends)) {
+    State.duelFriends = DEFAULT_DUEL_FRIENDS.map(friend => ({ ...friend }));
+  } else {
+    const normalizedFriends = [];
+    const seen = new Set();
+    for (const friend of State.duelFriends) {
+      if (!friend || typeof friend !== 'object') continue;
+      const name = typeof friend.name === 'string' ? friend.name.trim() : '';
+      if (!name || seen.has(name)) continue;
+      const entry = { ...friend, name };
+      normalizedFriends.push(entry);
+      seen.add(name);
+      if (normalizedFriends.length >= 20) break;
+    }
+    State.duelFriends = normalizedFriends.length
+      ? normalizedFriends
+      : DEFAULT_DUEL_FRIENDS.map(friend => ({ ...friend }));
+  }
   State.duelOpponent = null;
   ensureGroupRosters();
 }

--- a/Iquiz-assets/src/state/state.js
+++ b/Iquiz-assets/src/state/state.js
@@ -105,6 +105,13 @@ const DEFAULT_DUEL_INVITES = (() => {
   ];
 })();
 
+const DEFAULT_DUEL_FRIENDS = [
+  { id: 1, name: 'علی رضایی', score: 12450, avatar: 'https://i.pravatar.cc/60?img=3' },
+  { id: 2, name: 'سارا محمدی', score: 9800, avatar: 'https://i.pravatar.cc/60?img=5' },
+  { id: 3, name: 'رضا قاسمی', score: 15200, avatar: 'https://i.pravatar.cc/60?img=8' },
+  { id: 4, name: 'مریم احمدی', score: 7650, avatar: 'https://i.pravatar.cc/60?img=11' },
+];
+
 function normalizeKeyCount(value) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
@@ -219,6 +226,7 @@ const State = {
   duelLosses:0,
   pendingDuels:[],
   duelInvites: DEFAULT_DUEL_INVITES.map(invite => ({ ...invite })),
+  duelFriends: DEFAULT_DUEL_FRIENDS.map(friend => ({ ...friend })),
   duelHistory:[],
   achievements:{ firstWin:false, tenCorrect:false, streak3:false, vipBought:false },
   settings:{ sound:true, haptics:true, blockDuels:false },
@@ -359,5 +367,6 @@ export {
   buildRosterEntry,
   seededFloat,
   spendKeys,
-  DUEL_INVITE_TIMEOUT_MS
+  DUEL_INVITE_TIMEOUT_MS,
+  DEFAULT_DUEL_FRIENDS
 };


### PR DESCRIPTION
## Summary
- add default duel friends to the shared state and load persisted entries safely
- normalise the duel friend roster when bootstrapping the app and keep updates in local storage
- save duel friend changes whenever players are added or reordered so the "add to list" button reflects immediately

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5495553008326906a89088071c224