### PR TITLE
refactor question sourcing and harden seeding

### DIFF
--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -43,7 +43,12 @@ function parseAllowedOrigins(value) {
     .filter(Boolean);
 }
 
-const nodeEnv = process.env.NODE_ENV || DEFAULT_NODE_ENV;
+const nodeEnvRaw = process.env.NODE_ENV || DEFAULT_NODE_ENV;
+if (nodeEnvRaw === 'production' && !process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET required');
+}
+
+const nodeEnv = nodeEnvRaw;
 const mongoUri = process.env.MONGO_URI || DEFAULT_MONGO_URI;
 const mongoMaxPool = parseNumber(process.env.MONGO_MAX_POOL, DEFAULT_MONGO_MAX_POOL, { min: 1 });
 const port = parseNumber(process.env.PORT, DEFAULT_PORT, { min: 1 });
@@ -88,11 +93,8 @@ const env = {
 };
 
 if (!env.jwt.secret) {
-  if (env.isProduction) {
-    throw new Error('JWT_SECRET environment variable is required in production');
-  }
   env.jwt.secret = 'development-only-jwt-secret-change-me';
-  logger.warn('JWT_SECRET environment variable is not set. Using an insecure fallback secret for development.');
+  logger.warn('[auth] JWT_SECRET is missing; using an insecure development secret.');
 }
 
 module.exports = Object.freeze(env);

--- a/server/src/models/Category.js
+++ b/server/src/models/Category.js
@@ -56,8 +56,9 @@ const categorySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+categorySchema.index({ name: 1 }, { unique: true });
+categorySchema.index({ slug: 1 }, { unique: true, sparse: true });
 categorySchema.index({ provider: 1, providerCategoryId: 1 }, { unique: true, sparse: true });
-categorySchema.index({ slug: 1 }, { unique: true });
 categorySchema.index({ order: 1, createdAt: -1 });
 
 categorySchema.pre('validate', async function ensureSlug(next) {

--- a/server/src/routes/jservice.routes.js
+++ b/server/src/routes/jservice.routes.js
@@ -2,16 +2,11 @@
 
 const router = require('express').Router();
 
-const Question = require('../models/Question');
 const Category = require('../models/Category');
-const {
-  getFallbackQuestions,
-  getFallbackCategories,
-  mapCategoryDocument
-} = require('../services/publicContent');
+const { mapCategoryDocument, getFallbackCategories } = require('../services/publicContent');
+const QuestionService = require('../services/questionService');
 
 const MAX_REQUEST = 20;
-const FALLBACK_POOL_SIZE = 100;
 
 function clampCount(value) {
   const parsed = Number.parseInt(value, 10);
@@ -21,272 +16,61 @@ function clampCount(value) {
   return parsed;
 }
 
-function normalizeText(value) {
-  if (value === undefined || value === null) return '';
-  return String(value).trim();
-}
-
-function sanitizeOption(value) {
-  const normalized = normalizeText(value);
-  return normalized;
-}
-
-function resolveAnswer(options, index, fallbacks = []) {
-  if (Array.isArray(options) && options.length) {
-    const safeIndex = Number.parseInt(index, 10);
-    if (Number.isInteger(safeIndex) && safeIndex >= 0 && safeIndex < options.length) {
-      const candidate = sanitizeOption(options[safeIndex]);
-      if (candidate) return candidate;
-    }
-  }
-
-  for (const fallback of fallbacks) {
-    const candidate = sanitizeOption(fallback);
-    if (candidate) return candidate;
-  }
-
-  return '';
-}
-
-function mapCategoryForResponse(category) {
-  if (!category) return null;
-  const id = category.id || (category._id ? String(category._id) : null);
-  const title = normalizeText(category.title || category.displayName || category.name);
-  if (!title) return null;
-  return {
-    id,
-    title,
-    name: category.name ? normalizeText(category.name) || title : title,
-    displayName: category.displayName ? normalizeText(category.displayName) || title : title,
-    provider: category.provider || 'local',
-    color: category.color || '#60a5fa',
-    clues_count: category.clues_count ?? null
-  };
-}
-
-function mapQuestionDocumentToClue(doc) {
-  if (!doc) return null;
-
-  const id = doc._id ? String(doc._id) : doc.id;
-  const questionText = normalizeText(doc.text || doc.question || doc.title);
-  if (!id || !questionText) return null;
-
-  const rawChoices = Array.isArray(doc.choices)
-    ? doc.choices
-    : Array.isArray(doc.options)
-      ? doc.options
-      : Array.isArray(doc.meta?.options)
-        ? doc.meta.options
-        : [];
-  const options = rawChoices.map((choice) => sanitizeOption(choice)).filter(Boolean);
-
-  const fallbackAnswers = [];
-  if (typeof doc.correctAnswer === 'string') fallbackAnswers.push(doc.correctAnswer);
-  if (typeof doc.meta?.correctAnswer === 'string') fallbackAnswers.push(doc.meta.correctAnswer);
-
-  const indexCandidates = [
-    doc.correctIndex,
-    doc.correctIdx,
-    doc.answerIndex,
-    doc.meta?.correctIdx,
-    doc.meta?.correctIndex,
-    doc.meta?.answerIndex
-  ];
-  let resolvedIndex;
-  for (const candidate of indexCandidates) {
-    const parsed = Number.parseInt(candidate, 10);
-    if (Number.isInteger(parsed)) {
-      resolvedIndex = parsed;
-      break;
-    }
-  }
-
-  const answer = resolveAnswer(options, resolvedIndex, fallbackAnswers);
+function mapQuestionToClue(item) {
+  if (!item || !item.options || typeof item.correctIndex !== 'number') return null;
+  const answer = item.options[item.correctIndex];
   if (!answer) return null;
-
-  const categoryDoc = doc.categoryDoc && typeof doc.categoryDoc === 'object'
-    ? doc.categoryDoc
-    : null;
-  const categoryName = normalizeText(
-    doc.categoryName
-    || categoryDoc?.displayName
-    || categoryDoc?.name
-    || categoryDoc?.title
-  ) || 'عمومی';
-  const categoryId = categoryDoc?._id
-    ? String(categoryDoc._id)
-    : (doc.category && typeof doc.category?.toString === 'function'
-      ? doc.category.toString()
-      : (doc.category ? String(doc.category) : null));
-
   return {
-    id,
-    question: questionText,
+    id: item.id,
+    question: item.text,
     answer,
     category: {
-      id: categoryId,
-      title: categoryName,
-      name: categoryName,
-    },
-    value: null,
-    airdate: doc.createdAt ? new Date(doc.createdAt).toISOString() : null,
-  };
-}
-
-function mapFallbackQuestionToClue(item) {
-  if (!item) return null;
-  const id = item.id ? String(item.id) : null;
-  const questionText = normalizeText(item.text || item.title);
-  if (!id || !questionText) return null;
-
-  const options = Array.isArray(item.options)
-    ? item.options.map((choice) => sanitizeOption(choice)).filter(Boolean)
-    : [];
-  const answer = resolveAnswer(options, item.correctIdx ?? item.correctIndex ?? item.answerIndex);
-  if (!answer) return null;
-
-  const categoryName = normalizeText(item.categoryName || item.cat) || 'عمومی';
-
-  return {
-    id,
-    question: questionText,
-    answer,
-    category: {
-      id: item.categoryId || null,
-      title: categoryName,
-      name: categoryName,
-    },
-    value: null,
-    airdate: null,
-  };
-}
-
-function shuffle(array) {
-  const copy = array.slice();
-  for (let i = copy.length - 1; i > 0; i -= 1) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [copy[i], copy[j]] = [copy[j], copy[i]];
-  }
-  return copy;
-}
-
-async function fetchRandomQuestions(requested) {
-  const pipeline = [
-    { $match: { active: true, status: 'approved' } },
-    { $sample: { size: requested } },
-    {
-      $lookup: {
-        from: 'categories',
-        localField: 'category',
-        foreignField: '_id',
-        as: 'categoryDoc'
-      }
-    },
-    {
-      $addFields: {
-        categoryDoc: { $arrayElemAt: ['$categoryDoc', 0] }
-      }
+      title: item.category,
+      name: item.category
     }
-  ];
-
-  return Question.aggregate(pipeline);
+  };
 }
 
-function buildFallbackClues(count) {
-  if (count <= 0) return [];
-  const fallbackPool = getFallbackQuestions({ count: FALLBACK_POOL_SIZE });
-  if (!Array.isArray(fallbackPool) || fallbackPool.length === 0) return [];
-  const shuffled = shuffle(fallbackPool);
-  return shuffled
-    .slice(0, Math.min(count, shuffled.length))
-    .map((item) => mapFallbackQuestionToClue(item))
-    .filter(Boolean);
-}
-
-async function gatherClues(requested) {
-  let documents = [];
+router.get('/random', async (req, res, next) => {
   try {
-    documents = await fetchRandomQuestions(requested);
+    const count = clampCount(req.query.count);
+    const { ok, items, countRequested } = await QuestionService.getQuestions({
+      count,
+      category: req.query.category,
+      difficulty: req.query.difficulty
+    });
+
+    const clues = Array.isArray(items) ? items.map(mapQuestionToClue).filter(Boolean) : [];
+    res.json({
+      ok,
+      data: clues,
+      meta: {
+        requested: countRequested,
+        delivered: clues.length,
+        source: 'database'
+      }
+    });
   } catch (error) {
-    documents = [];
+    next(error);
   }
+});
 
-  let clues = Array.isArray(documents)
-    ? documents.map((doc) => mapQuestionDocumentToClue(doc)).filter(Boolean)
-    : [];
-
-  if (clues.length > requested) {
-    clues = clues.slice(0, requested);
-  }
-
-  let source = clues.length ? 'database' : 'fallback';
-
-  if (clues.length < requested) {
-    const fallbackClues = buildFallbackClues(requested - clues.length);
-    if (fallbackClues.length) {
-      source = clues.length ? 'mixed' : 'fallback';
-      clues = clues.concat(fallbackClues).slice(0, requested);
-    }
-  }
-
-  return { clues, source };
-}
-
-async function gatherCategories() {
+router.get('/categories', async (req, res, next) => {
   try {
     const docs = await Category.find({}).sort({ order: 1, createdAt: -1 });
     const mapped = docs
       .map((doc) => mapCategoryDocument(doc))
-      .map((category) => mapCategoryForResponse(category))
       .filter(Boolean);
     if (mapped.length) {
-      return { categories: mapped, source: 'database' };
+      res.json({ ok: true, data: mapped, meta: { count: mapped.length, source: 'database' } });
+      return;
     }
   } catch (error) {
-    // ignore database errors and fall back to static data
+    // ignore and fall back to static data
   }
 
-  const fallback = getFallbackCategories()
-    .map((category) => mapCategoryForResponse(category))
-    .filter(Boolean);
-  return { categories: fallback, source: 'fallback' };
-}
-
-async function handleClueRequest(req, res, next) {
-  try {
-    const requested = clampCount(req.query.count);
-    const { clues, source } = await gatherClues(requested);
-    res.json({
-      ok: true,
-      data: clues,
-      meta: {
-        requested,
-        delivered: clues.length,
-        source
-      }
-    });
-  } catch (error) {
-    next(error);
-  }
-}
-
-router.get('/random', handleClueRequest);
-router.get('/clues', handleClueRequest);
-
-router.get('/categories', async (req, res, next) => {
-  try {
-    const { categories, source } = await gatherCategories();
-    res.json({
-      ok: true,
-      data: categories,
-      meta: {
-        count: categories.length,
-        source
-      }
-    });
-  } catch (error) {
-    next(error);
-  }
+  const fallback = getFallbackCategories();
+  res.json({ ok: true, data: fallback, meta: { count: fallback.length, source: 'fallback' } });
 });
 
 module.exports = router;

--- a/server/src/services/duelEngine.js
+++ b/server/src/services/duelEngine.js
@@ -1,0 +1,51 @@
+const logger = require('../config/logger');
+const QuestionService = require('./questionService');
+
+const MAX_DUEL_QUESTIONS = 20;
+
+function sanitizeRequested(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 12;
+  return Math.min(parsed, MAX_DUEL_QUESTIONS);
+}
+
+async function loadDuelQuestions(ctx = {}) {
+  const requested = sanitizeRequested(ctx.requested ?? ctx.count ?? ctx.rounds);
+  const category = typeof ctx.category === 'string' ? ctx.category.trim() : '';
+  const difficulty = typeof ctx.difficulty === 'string' ? ctx.difficulty.trim().toLowerCase() : '';
+
+  const { ok, items } = await QuestionService.getQuestions({
+    count: requested,
+    category,
+    difficulty
+  });
+
+  if (!ok || !Array.isArray(items) || items.length === 0) {
+    throw new Error('no_questions');
+  }
+
+  const seen = new Set();
+  const unique = [];
+  for (const item of items) {
+    if (!item || !item.id) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    unique.push(item);
+    if (unique.length === requested) break;
+  }
+
+  logger.info(
+    `[duel] requested=${requested} delivered=${unique.length} category=${category || 'any'} difficulty=${difficulty || 'any'}`
+  );
+
+  if (!unique.length) {
+    throw new Error('no_questions');
+  }
+
+  return unique;
+}
+
+module.exports = {
+  MAX_DUEL_QUESTIONS,
+  loadDuelQuestions
+};

--- a/server/src/services/questionService.js
+++ b/server/src/services/questionService.js
@@ -1,0 +1,229 @@
+const mongoose = require('mongoose');
+
+const Question = require('../models/Question');
+const logger = require('../config/logger');
+
+const MAX_PER_REQUEST = 30;
+const FETCH_MULTIPLIER = 2;
+const MAX_FETCH_LIMIT = MAX_PER_REQUEST * 3;
+const ALLOWED_DIFFICULTIES = new Set(['easy', 'medium', 'hard']);
+
+function sanitizeCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 10;
+  if (parsed <= 0) return 1;
+  if (parsed > MAX_PER_REQUEST) return MAX_PER_REQUEST;
+  return parsed;
+}
+
+function sanitizeDifficulty(value) {
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_DIFFICULTIES.has(normalized) ? normalized : '';
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildCategoryFilter(category) {
+  const trimmed = typeof category === 'string' ? category.trim() : '';
+  if (!trimmed) return null;
+
+  if (mongoose.Types.ObjectId.isValid(trimmed)) {
+    return { category: new mongoose.Types.ObjectId(trimmed) };
+  }
+
+  const normalized = trimmed.toLowerCase();
+  const regex = new RegExp(`^${escapeRegExp(trimmed)}$`, 'i');
+  const slugRegex = new RegExp(`^${escapeRegExp(normalized)}$`, 'i');
+
+  return {
+    $or: [
+      { categorySlug: normalized },
+      { categorySlug: slugRegex },
+      { categoryName: regex }
+    ]
+  };
+}
+
+function extractOptions(doc) {
+  const source = Array.isArray(doc.options)
+    ? doc.options
+    : Array.isArray(doc.choices)
+      ? doc.choices
+      : [];
+
+  return source
+    .map((option) => (typeof option === 'string' ? option.trim() : String(option ?? '').trim()))
+    .filter((option) => option.length > 0)
+    .slice(0, 4);
+}
+
+function normalizeQuestionDocument(doc) {
+  if (!doc) return null;
+  const id = doc._id ? String(doc._id) : (doc.id ? String(doc.id) : null);
+  if (!id) return null;
+
+  const text = typeof doc.text === 'string' && doc.text.trim()
+    ? doc.text.trim()
+    : typeof doc.question === 'string' && doc.question.trim()
+      ? doc.question.trim()
+      : '';
+
+  const options = extractOptions(doc);
+
+  const indexCandidates = [doc.correctIndex, doc.correctIdx, doc.answerIndex];
+  let correctIndex = -1;
+  for (const candidate of indexCandidates) {
+    const parsed = Number(candidate);
+    if (Number.isInteger(parsed) && parsed >= 0 && parsed < options.length) {
+      correctIndex = parsed;
+      break;
+    }
+  }
+
+  if (correctIndex < 0 && options.length) {
+    const answerCandidates = [doc.correctAnswer, doc.answer, doc.meta?.correctAnswer]
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean);
+
+    const normalizedOptions = options.map((option) => option.toLowerCase());
+    for (const candidate of answerCandidates) {
+      const normalizedCandidate = candidate.toLowerCase();
+      const matchIndex = normalizedOptions.indexOf(normalizedCandidate);
+      if (matchIndex >= 0 && matchIndex < options.length) {
+        correctIndex = matchIndex;
+        break;
+      }
+    }
+  }
+
+  const category = typeof doc.categorySlug === 'string' && doc.categorySlug.trim()
+    ? doc.categorySlug.trim()
+    : typeof doc.categoryName === 'string' && doc.categoryName.trim()
+      ? doc.categoryName.trim()
+      : 'عمومی';
+
+  const difficulty = typeof doc.difficulty === 'string' && doc.difficulty.trim()
+    ? doc.difficulty.trim().toLowerCase()
+    : '';
+
+  return {
+    id,
+    text,
+    options,
+    correctIndex,
+    category,
+    difficulty
+  };
+}
+
+function isValidQuestion(question) {
+  if (!question) return false;
+  if (typeof question.text !== 'string' || !question.text.trim()) return false;
+  if (!Array.isArray(question.options) || question.options.length !== 4) return false;
+  if (!question.options.every((option) => typeof option === 'string' && option.trim())) return false;
+  if (!Number.isInteger(question.correctIndex) || question.correctIndex < 0 || question.correctIndex > 3) return false;
+  return true;
+}
+
+function buildBaseQuery(params) {
+  const query = {
+    active: { $ne: false },
+    $and: [
+      {
+        $or: [
+          { status: { $exists: false } },
+          { status: 'approved' }
+        ]
+      }
+    ]
+  };
+
+  const difficulty = sanitizeDifficulty(params.difficulty);
+  if (difficulty) {
+    query.difficulty = difficulty;
+  }
+
+  const categoryFilter = buildCategoryFilter(params.category || params.categoryId || params.categorySlug);
+  if (categoryFilter) {
+    if (categoryFilter.category) {
+      query.category = categoryFilter.category;
+    }
+    if (Array.isArray(categoryFilter.$or) && categoryFilter.$or.length) {
+      query.$and.push({ $or: categoryFilter.$or });
+    }
+  }
+
+  return query;
+}
+
+async function getQuestions(params = {}) {
+  const countRequested = sanitizeCount(params.count);
+  const query = buildBaseQuery(params);
+  const fetchLimit = Math.min(
+    Math.max(countRequested * FETCH_MULTIPLIER, countRequested),
+    MAX_FETCH_LIMIT
+  );
+
+  let totalMatched = 0;
+  try {
+    totalMatched = await Question.countDocuments(query);
+  } catch (error) {
+    logger.warn(`[questions] count failed: ${error.message}`);
+  }
+
+  let raw = [];
+  try {
+    raw = await Question.find(query)
+      .sort({ createdAt: -1 })
+      .limit(fetchLimit)
+      .lean();
+  } catch (error) {
+    logger.error(`[questions] query failed: ${error.message}`);
+    return {
+      ok: false,
+      countRequested,
+      countReturned: 0,
+      totalMatched,
+      items: []
+    };
+  }
+
+  const normalized = [];
+  const seen = new Set();
+  for (const doc of raw) {
+    const question = normalizeQuestionDocument(doc);
+    if (!isValidQuestion(question)) continue;
+    if (seen.has(question.id)) continue;
+    seen.add(question.id);
+    normalized.push(question);
+    if (normalized.length >= countRequested) {
+      break;
+    }
+  }
+
+  const items = normalized.slice(0, countRequested);
+
+  logger.info(
+    `[questions] want=${countRequested} raw=${raw.length} normalized=${normalized.length} returned=${items.length}`
+  );
+
+  return {
+    ok: true,
+    countRequested,
+    countReturned: items.length,
+    totalMatched,
+    items
+  };
+}
+
+module.exports = {
+  MAX_PER_REQUEST,
+  getQuestions,
+  normalizeQuestionDocument,
+  isValidQuestion,
+  sanitizeCount,
+  sanitizeDifficulty
+};

--- a/server/test/categorySeeder.test.js
+++ b/server/test/categorySeeder.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const {
+  seedCategories,
+  STATIC_CATEGORY_ENTRIES,
+  pickNonUnique
+} = require('../src/services/categorySeeder');
+
+test('seedCategories uses identity filters and separates unique fields', async () => {
+  const sampleEntries = STATIC_CATEGORY_ENTRIES.slice(0, 2);
+  const calls = [];
+  const stub = {
+    async updateOne(filter, update) {
+      calls.push({ filter, update });
+      return { upsertedCount: 1, modifiedCount: 0 };
+    }
+  };
+
+  const result = await seedCategories(stub, sampleEntries);
+  assert.strictEqual(result.inserted, sampleEntries.length);
+  assert.strictEqual(result.updated, 0);
+
+  assert.ok(calls.length >= 1, 'updateOne should be called');
+  const [{ filter, update }] = calls;
+  assert.ok(filter.$or.some((condition) => condition.name === sampleEntries[0].name));
+  assert.ok(filter.$or.some((condition) => condition.slug === sampleEntries[0].slug));
+  assert.ok(filter.$or.some((condition) => condition.provider === sampleEntries[0].provider));
+  assert.ok(update.$setOnInsert.name === sampleEntries[0].name);
+  assert.ok(update.$setOnInsert.slug === sampleEntries[0].slug);
+  assert.ok(!Object.prototype.hasOwnProperty.call(update.$set, 'name'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(update.$set, 'slug'));
+});
+
+test('seedCategories second run reports updates without inserts', async () => {
+  const entry = STATIC_CATEGORY_ENTRIES[0];
+  let callCount = 0;
+  const stub = {
+    async updateOne() {
+      callCount += 1;
+      if (callCount === 1) {
+        return { upsertedCount: 1, modifiedCount: 0 };
+      }
+      return { upsertedCount: 0, modifiedCount: 1 };
+    }
+  };
+
+  const first = await seedCategories(stub, [entry]);
+  const second = await seedCategories(stub, [entry]);
+
+  assert.deepStrictEqual(first, { inserted: 1, updated: 0 });
+  assert.deepStrictEqual(second, { inserted: 0, updated: 1 });
+});
+
+test('pickNonUnique strips identity fields', () => {
+  const entry = STATIC_CATEGORY_ENTRIES[0];
+  const nonUnique = pickNonUnique(entry);
+  assert.ok(!('name' in nonUnique));
+  assert.ok(!('slug' in nonUnique));
+  assert.ok(!('provider' in nonUnique));
+  assert.ok(!('providerCategoryId' in nonUnique));
+});

--- a/server/test/duelEngine.test.js
+++ b/server/test/duelEngine.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const QuestionService = require('../src/services/questionService');
+const { loadDuelQuestions, MAX_DUEL_QUESTIONS } = require('../src/services/duelEngine');
+
+test('loadDuelQuestions enforces cap and removes duplicates', async () => {
+  const original = QuestionService.getQuestions;
+  let capturedCount = null;
+
+  QuestionService.getQuestions = async (params) => {
+    capturedCount = params.count;
+    return {
+      ok: true,
+      countRequested: params.count,
+      items: [
+        { id: 'a', text: 'A', options: ['1', '2', '3', '4'], correctIndex: 0, category: 'general' },
+        { id: 'a', text: 'A copy', options: ['1', '2', '3', '4'], correctIndex: 1, category: 'general' },
+        { id: 'b', text: 'B', options: ['1', '2', '3', '4'], correctIndex: 2, category: 'general' }
+      ]
+    };
+  };
+
+  try {
+    const questions = await loadDuelQuestions({ requested: MAX_DUEL_QUESTIONS + 5, category: 'general' });
+    assert.strictEqual(capturedCount, MAX_DUEL_QUESTIONS);
+    assert.strictEqual(questions.length, 2);
+    const ids = new Set(questions.map((q) => q.id));
+    assert.strictEqual(ids.size, questions.length);
+  } finally {
+    QuestionService.getQuestions = original;
+  }
+});
+
+test('loadDuelQuestions throws when service returns no questions', async () => {
+  const original = QuestionService.getQuestions;
+  QuestionService.getQuestions = async () => ({ ok: true, items: [] });
+
+  try {
+    await assert.rejects(loadDuelQuestions({ requested: 5 }), /no_questions/);
+  } finally {
+    QuestionService.getQuestions = original;
+  }
+});

--- a/server/test/questionService.test.js
+++ b/server/test/questionService.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const Question = require('../src/models/Question');
+const QuestionService = require('../src/services/questionService');
+
+function stubQuestionModel({ docs = [], total = docs.length }) {
+  const originalFind = Question.find;
+  const originalCount = Question.countDocuments;
+  let capturedLimit = null;
+
+  Question.countDocuments = async () => total;
+  Question.find = () => ({
+    sort() { return this; },
+    limit(value) { capturedLimit = value; return this; },
+    lean: async () => docs
+  });
+
+  return {
+    getLimit() {
+      return capturedLimit;
+    },
+    restore() {
+      Question.find = originalFind;
+      Question.countDocuments = originalCount;
+    }
+  };
+}
+
+test('getQuestions enforces maximum per request', async () => {
+  const docs = new Array(40).fill(null).map((_, index) => ({
+    _id: `q-${index}`,
+    text: `Question ${index}`,
+    options: ['a', 'b', 'c', 'd'],
+    correctIndex: index % 4,
+    categorySlug: 'general'
+  }));
+  const stub = stubQuestionModel({ docs, total: 400 });
+
+  try {
+    const result = await QuestionService.getQuestions({ count: 100 });
+    assert.strictEqual(result.countRequested, QuestionService.MAX_PER_REQUEST);
+    assert.ok(result.ok);
+    assert.ok(result.countReturned <= QuestionService.MAX_PER_REQUEST);
+    assert.ok(stub.getLimit() <= QuestionService.MAX_PER_REQUEST * 3);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getQuestions normalises and filters invalid documents', async () => {
+  const docs = [
+    {
+      _id: 'valid',
+      text: '   Capital of Iran?   ',
+      choices: [' تهران ', 'اصفهان', 'شیراز', 'تبریز'],
+      correctIdx: 0,
+      categoryName: 'عمومی'
+    },
+    {
+      _id: 'invalid',
+      text: 'Too few options',
+      options: ['one'],
+      correctIndex: 0,
+      categorySlug: 'general'
+    },
+    {
+      _id: 'duplicate',
+      text: 'Duplicate question',
+      choices: ['a', 'b', 'c', 'd'],
+      correctIndex: 1,
+      categorySlug: 'general'
+    },
+    {
+      _id: 'duplicate',
+      text: 'Duplicate question copy',
+      choices: ['a', 'b', 'c', 'd'],
+      correctIndex: 1,
+      categorySlug: 'general'
+    }
+  ];
+
+  const stub = stubQuestionModel({ docs, total: docs.length });
+
+  try {
+    const result = await QuestionService.getQuestions({ count: 5 });
+    assert.ok(result.ok);
+    assert.strictEqual(result.countReturned, 2);
+    const [first] = result.items;
+    assert.deepStrictEqual(first.options, ['تهران', 'اصفهان', 'شیراز', 'تبریز']);
+    assert.strictEqual(first.correctIndex, 0);
+    assert.strictEqual(first.text, 'Capital of Iran?');
+    assert.strictEqual(first.category, 'عمومی');
+  } finally {
+    stub.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- make the category seeder idempotent with unified identity filtering, logging and a single-run guard
- replace external question providers with a Mongo-backed question service that powers quiz and duel retrieval and updates the public/jservice routes
- enforce JWT secret requirements in production and add tests covering the new seeding and question-loading flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57dae27308326824c915c962ad652