### PR TITLE
Add group pairing strategies and configuration

### DIFF
--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -6,6 +6,9 @@ const DEFAULT_MONGO_URI = 'mongodb://localhost:27017/iquiz';
 const DEFAULT_MONGO_MAX_POOL = 10;
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
+const DEFAULT_GROUP_PAIRING_MODE = 'bench';
+const DEFAULT_GROUP_ROSTER_LOCK_SECONDS = 30;
+const DEFAULT_GROUP_ROTATION_WINDOW = 1;
 
 const truthyValues = new Set(['true', '1', 'yes', 'y', 'on']);
 const falsyValues = new Set(['false', '0', 'no', 'n', 'off']);
@@ -43,6 +46,13 @@ function parseAllowedOrigins(value) {
     .filter(Boolean);
 }
 
+function parsePairingMode(value, defaultValue = DEFAULT_GROUP_PAIRING_MODE) {
+  if (typeof value !== 'string') return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  return ['bench', 'rotate', 'duplicate'].includes(normalized) ? normalized : defaultValue;
+}
+
 const nodeEnvRaw = process.env.NODE_ENV || DEFAULT_NODE_ENV;
 if (nodeEnvRaw === 'production' && !process.env.JWT_SECRET) {
   throw new Error('JWT_SECRET required');
@@ -61,6 +71,17 @@ const openAiOrganization = process.env.OPENAI_ORG || process.env.OPENAI_ORGANIZA
 const openAiProject = process.env.OPENAI_PROJECT || '';
 
 const allowReviewModeAll = parseBoolean(process.env.ALLOW_REVIEW_MODE_ALL, true);
+const groupPairingMode = parsePairingMode(process.env.GROUP_PAIRING_MODE, DEFAULT_GROUP_PAIRING_MODE);
+const groupRosterLockSeconds = parseNumber(
+  process.env.GROUP_ROSTER_LOCK_SECONDS,
+  DEFAULT_GROUP_ROSTER_LOCK_SECONDS,
+  { min: 0 }
+);
+const groupRotationWindow = parseNumber(
+  process.env.GROUP_ROTATION_WINDOW,
+  DEFAULT_GROUP_ROTATION_WINDOW,
+  { min: 1 }
+);
 
 const env = {
   nodeEnv,
@@ -89,6 +110,11 @@ const env = {
   },
   features: {
     allowReviewModeAll
+  },
+  groupBattles: {
+    pairingMode: groupPairingMode,
+    rosterLockSeconds: groupRosterLockSeconds,
+    rotationWindow: groupRotationWindow
   }
 };
 

--- a/server/src/services/groupPairing.js
+++ b/server/src/services/groupPairing.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const VALID_MODES = new Set(['bench', 'rotate', 'duplicate']);
+const DEFAULT_MODE = 'bench';
+const DEFAULT_ROTATION_WINDOW = 1;
+
+function normalizeMode(mode) {
+  if (typeof mode !== 'string') return DEFAULT_MODE;
+  const trimmed = mode.trim().toLowerCase();
+  if (VALID_MODES.has(trimmed)) return trimmed;
+  return DEFAULT_MODE;
+}
+
+function cloneMembers(team) {
+  if (!team || !Array.isArray(team.members)) return [];
+  return team.members.slice();
+}
+
+function safeRotationWindow(value) {
+  const parsed = Number.parseInt(String(value ?? DEFAULT_ROTATION_WINDOW), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_ROTATION_WINDOW;
+  return parsed;
+}
+
+function rotateArray(items, offset) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  const size = items.length;
+  if (!Number.isFinite(offset) || offset <= 0) return items.slice();
+  const normalized = offset % size;
+  if (normalized === 0) return items.slice();
+  return items.slice(normalized).concat(items.slice(0, normalized));
+}
+
+function rotateSlice(arr, start, count, offset) {
+  const paired = arr.slice(0, start);
+  if (!count || count <= 0) {
+    return { paired, bench: [] };
+  }
+
+  const extras = arr.slice(start, start + count);
+  if (extras.length <= 1) {
+    return { paired, bench: extras.slice() };
+  }
+
+  const rotated = rotateArray(extras, offset);
+  return { paired, bench: rotated };
+}
+
+function zip(a, b, n) {
+  const pairs = [];
+  for (let i = 0; i < n; i += 1) {
+    pairs.push([a[i], b[i]]);
+  }
+  return pairs;
+}
+
+function createPairObjects(pairedA, pairedB) {
+  const len = Math.min(pairedA.length, pairedB.length);
+  const pairs = [];
+  for (let i = 0; i < len; i += 1) {
+    pairs.push({ a: pairedA[i], b: pairedB[i], index: i });
+  }
+  return pairs;
+}
+
+function duplicateMembers(source, targetLength) {
+  const size = source.length;
+  const duplicated = [];
+  for (let i = 0; i < targetLength; i += 1) {
+    duplicated.push(source[i % size]);
+  }
+  return duplicated;
+}
+
+function pairTeams(teamA = { id: 'A', members: [] }, teamB = { id: 'B', members: [] }, mode = DEFAULT_MODE, options = {}) {
+  const normalizedMode = normalizeMode(mode);
+  const membersA = cloneMembers(teamA);
+  const membersB = cloneMembers(teamB);
+  const lenA = membersA.length;
+  const lenB = membersB.length;
+  const minSize = Math.min(lenA, lenB);
+  const maxSize = Math.max(lenA, lenB);
+
+  if (normalizedMode !== 'duplicate' && (lenA === 0 || lenB === 0)) {
+    const benchA = membersA.slice();
+    const benchB = membersB.slice();
+    const result = {
+      pairs: [],
+      benchA,
+      benchB,
+      meta: {
+        mode: normalizedMode,
+        minSize,
+        maxSize
+      }
+    };
+    console.info('[group-pairing]', {
+      mode: normalizedMode,
+      round: options.round ?? 0,
+      a: lenA,
+      b: lenB,
+      pairs: 0,
+      benchA: benchA.length,
+      benchB: benchB.length
+    });
+    return result;
+  }
+
+  if (normalizedMode === 'duplicate') {
+    if (lenA === 0 || lenB === 0) {
+      const benchA = membersA.slice();
+      const benchB = membersB.slice();
+      const result = {
+        pairs: [],
+        benchA,
+        benchB,
+        meta: {
+          mode: normalizedMode,
+          minSize,
+          maxSize,
+          duplicatedFrom: lenA === 0 && lenB === 0 ? undefined : lenA === 0 ? 'A' : 'B'
+        }
+      };
+      console.info('[group-pairing]', {
+        mode: normalizedMode,
+        round: options.round ?? 0,
+        a: lenA,
+        b: lenB,
+        pairs: 0,
+        benchA: benchA.length,
+        benchB: benchB.length
+      });
+      return result;
+    }
+
+    const targetLength = Math.max(lenA, lenB);
+    const pairedA = lenA === targetLength ? membersA.slice() : duplicateMembers(membersA, targetLength);
+    const pairedB = lenB === targetLength ? membersB.slice() : duplicateMembers(membersB, targetLength);
+    const pairs = createPairObjects(pairedA, pairedB);
+    const duplicatedFrom = lenA === lenB ? undefined : lenA < lenB ? 'A' : 'B';
+    const result = {
+      pairs,
+      benchA: [],
+      benchB: [],
+      meta: {
+        mode: normalizedMode,
+        minSize,
+        maxSize,
+        duplicatedFrom
+      }
+    };
+    console.info('[group-pairing]', {
+      mode: normalizedMode,
+      round: options.round ?? 0,
+      a: lenA,
+      b: lenB,
+      pairs: pairs.length,
+      benchA: 0,
+      benchB: 0
+    });
+    return result;
+  }
+
+  const round = Number.isFinite(options.round) ? Number(options.round) : 0;
+  const rotationWindow = safeRotationWindow(options.rotationWindow ?? DEFAULT_ROTATION_WINDOW);
+
+  let pairedA = membersA.slice(0, minSize);
+  let benchA = membersA.slice(minSize);
+  let pairedB = membersB.slice(0, minSize);
+  let benchB = membersB.slice(minSize);
+
+  if (normalizedMode === 'rotate') {
+    if (lenA > lenB) {
+      const extraA = lenA - minSize;
+      const offset = extraA > 0 ? (round * rotationWindow) % Math.max(1, extraA) : 0;
+      const rotated = rotateSlice(membersA, minSize, extraA, offset);
+      pairedA = rotated.paired;
+      benchA = rotated.bench;
+    }
+
+    if (lenB > lenA) {
+      const extraB = lenB - minSize;
+      const offset = extraB > 0 ? (round * rotationWindow) % Math.max(1, extraB) : 0;
+      const rotated = rotateSlice(membersB, minSize, extraB, offset);
+      pairedB = rotated.paired;
+      benchB = rotated.bench;
+    }
+  }
+
+  const pairCount = Math.min(pairedA.length, pairedB.length, minSize);
+  const zipped = zip(pairedA, pairedB, pairCount);
+  const pairs = zipped.map(([a, b], index) => ({ a, b, index }));
+
+  const result = {
+    pairs,
+    benchA,
+    benchB,
+    meta: {
+      mode: normalizedMode,
+      minSize,
+      maxSize
+    }
+  };
+
+  console.info('[group-pairing]', {
+    mode: normalizedMode,
+    round,
+    a: lenA,
+    b: lenB,
+    pairs: pairs.length,
+    benchA: benchA.length,
+    benchB: benchB.length
+  });
+
+  return result;
+}
+
+module.exports = {
+  VALID_MODES,
+  DEFAULT_MODE,
+  pairTeams,
+  zip,
+  rotateSlice
+};

--- a/server/src/services/groupPairing.ts
+++ b/server/src/services/groupPairing.ts
@@ -1,0 +1,9 @@
+export type Player = { id: string; username?: string; joinedAt: number; active?: boolean };
+export type Team = { id: string; members: Player[] };
+export type Pair = { a: Player; b: Player; index: number };
+export type PairingMeta = { mode: 'bench' | 'rotate' | 'duplicate'; minSize: number; maxSize: number; duplicatedFrom?: 'A' | 'B' };
+export type PairingResult = { pairs: Pair[]; benchA: Player[]; benchB: Player[]; meta: PairingMeta };
+export type PairingMode = 'bench' | 'rotate' | 'duplicate';
+export type PairingOptions = { round?: number; rotationWindow?: number };
+
+export { pairTeams } from './groupPairing.js';

--- a/server/test/groupPairing.test.js
+++ b/server/test/groupPairing.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { pairTeams } = require('../src/services/groupPairing');
+
+function createPlayer(id) {
+  return { id: String(id), joinedAt: id * 1000 };
+}
+
+test('bench mode pairs up to min size and benches extras', () => {
+  const teamA = { id: 'A', members: [createPlayer(1), createPlayer(2), createPlayer(3)] };
+  const teamB = {
+    id: 'B',
+    members: [createPlayer(4), createPlayer(5), createPlayer(6), createPlayer(7), createPlayer(8)]
+  };
+
+  const result = pairTeams(teamA, teamB, 'bench');
+
+  assert.equal(result.pairs.length, 3);
+  assert.equal(result.benchA.length, 0);
+  assert.equal(result.benchB.length, 2);
+  assert.deepEqual(
+    result.benchB.map((player) => player.id),
+    ['7', '8']
+  );
+  assert.deepEqual(
+    result.pairs.map((pair) => [pair.a.id, pair.b.id]),
+    [
+      ['1', '4'],
+      ['2', '5'],
+      ['3', '6']
+    ]
+  );
+});
+
+test('rotate mode rotates which extras are benched based on round', () => {
+  const teamA = { id: 'A', members: [createPlayer(1), createPlayer(2), createPlayer(3)] };
+  const teamB = {
+    id: 'B',
+    members: [createPlayer(4), createPlayer(5), createPlayer(6), createPlayer(7), createPlayer(8)]
+  };
+
+  const round0 = pairTeams(teamA, teamB, 'rotate', { round: 0, rotationWindow: 1 });
+  const round1 = pairTeams(teamA, teamB, 'rotate', { round: 1, rotationWindow: 1 });
+  const round2 = pairTeams(teamA, teamB, 'rotate', { round: 2, rotationWindow: 1 });
+
+  assert.deepEqual(round0.benchB.map((player) => player.id), ['7', '8']);
+  assert.deepEqual(round1.benchB.map((player) => player.id), ['8', '7']);
+  assert.deepEqual(round2.benchB.map((player) => player.id), ['7', '8']);
+
+  assert.equal(round0.pairs.length, 3);
+  assert.equal(round1.pairs.length, 3);
+  assert.equal(round2.pairs.length, 3);
+});
+
+test('duplicate mode reuses smaller team members without benches', () => {
+  const teamA = { id: 'A', members: [createPlayer(1), createPlayer(2)] };
+  const teamB = {
+    id: 'B',
+    members: [createPlayer(3), createPlayer(4), createPlayer(5), createPlayer(6), createPlayer(7)]
+  };
+
+  const result = pairTeams(teamA, teamB, 'duplicate');
+
+  assert.equal(result.pairs.length, 5);
+  assert.deepEqual(
+    result.pairs.map((pair) => [pair.a.id, pair.b.id]),
+    [
+      ['1', '3'],
+      ['2', '4'],
+      ['1', '5'],
+      ['2', '6'],
+      ['1', '7']
+    ]
+  );
+  assert.equal(result.benchA.length, 0);
+  assert.equal(result.benchB.length, 0);
+  assert.equal(result.meta.duplicatedFrom, 'A');
+});
+
+test('symmetric teams have no bench or duplication', () => {
+  const teamA = { id: 'A', members: [createPlayer(1), createPlayer(2), createPlayer(3)] };
+  const teamB = { id: 'B', members: [createPlayer(4), createPlayer(5), createPlayer(6)] };
+
+  const benchMode = pairTeams(teamA, teamB, 'bench');
+  const rotateMode = pairTeams(teamA, teamB, 'rotate', { round: 3 });
+  const duplicateMode = pairTeams(teamA, teamB, 'duplicate');
+
+  assert.equal(benchMode.benchA.length, 0);
+  assert.equal(benchMode.benchB.length, 0);
+  assert.equal(rotateMode.benchA.length, 0);
+  assert.equal(rotateMode.benchB.length, 0);
+  assert.equal(duplicateMode.meta.duplicatedFrom, undefined);
+  assert.equal(duplicateMode.pairs.length, 3);
+});
+
+test('empty team results in benches only', () => {
+  const teamA = { id: 'A', members: [] };
+  const teamB = { id: 'B', members: [createPlayer(1), createPlayer(2)] };
+
+  const benchMode = pairTeams(teamA, teamB, 'bench');
+  assert.equal(benchMode.pairs.length, 0);
+  assert.equal(benchMode.benchA.length, 0);
+  assert.equal(benchMode.benchB.length, 2);
+
+  const duplicateMode = pairTeams(teamA, teamB, 'duplicate');
+  assert.equal(duplicateMode.pairs.length, 0);
+  assert.equal(duplicateMode.benchB.length, 2);
+  assert.equal(duplicateMode.meta.duplicatedFrom, 'A');
+});


### PR DESCRIPTION
## Summary
- introduce configurable group pairing strategies (bench, rotate, duplicate) with shared helpers
- surface group battle configuration defaults for pairing mode, roster lock window, and rotation window
- add unit coverage for new pairing behaviours across bench, rotate, duplicate, and empty team scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d591831be88326bc6122d32780f371