### PR TITLE
Update quiz timeout behavior and hide extra details

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -388,13 +388,13 @@
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-2 text-sm gap-2">
           <div class="flex items-center gap-2 flex-wrap justify-center sm:justify-start">
             <span id="quiz-cat" class="chip"><i class="fas fa-folder ml-1"></i> عمومی</span>
-            <span id="quiz-diff" class="chip"><i class="fas fa-signal ml-1"></i> آسان</span>
+            <span id="quiz-diff" class="chip hidden"><i class="fas fa-signal ml-1"></i> آسان</span>
             <span id="quiz-code" class="chip hidden"><i class="fas fa-barcode ml-1"></i> <span id="quiz-code-value">—</span></span>
             <span class="chip"><i class="fas fa-hashtag ml-1"></i> <span id="qnum">۱</span>/<span id="qtotal">۵</span></span>
           </div>
           <div class="flex items-center gap-2 justify-center sm:justify-end">
-            <span class="chip"><i class="fas fa-key text-yellow-400 ml-1"></i> <span id="lives">۳</span></span>
-            <span class="chip"><i class="fas fa-coins text-yellow-300 ml-1"></i> <span id="coins">۰</span></span>
+            <span class="chip hidden"><i class="fas fa-key text-yellow-400 ml-1"></i> <span id="lives">۳</span></span>
+            <span class="chip hidden"><i class="fas fa-coins text-yellow-300 ml-1"></i> <span id="coins">۰</span></span>
           </div>
         </div>
         <div id="duel-banner" class="hidden mb-2 flex items-center justify-center">

--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -202,22 +202,19 @@ export function lifePause() {
 export function renderQuestionUI(q) {
   const questionValid = isValidQuestion(q);
   const catLabel = State.quiz.cat || q.cat || '—';
-  const diffLabel = State.quiz.diff || q.diff || '—';
   $('#quiz-cat').innerHTML = `<i class="fas fa-folder ml-1"></i> ${catLabel}`;
-  $('#quiz-diff').innerHTML = `<i class="fas fa-signal ml-1"></i> ${diffLabel}`;
+  const diffChip = $('#quiz-diff');
+  if (diffChip) {
+    diffChip.textContent = '';
+    diffChip.classList.add('hidden');
+  }
   $('#qnum').textContent = faNum(Math.min(State.quiz.idx + 1, Math.max(1, State.quiz.list.length)));
   $('#qtotal').textContent = faNum(State.quiz.list.length);
   const codeChip = $('#quiz-code');
   const codeValueEl = $('#quiz-code-value');
   if (codeChip && codeValueEl) {
-    const codeValue = (q.id || '').toString().trim();
-    if (codeValue) {
-      codeValueEl.textContent = codeValue;
-      codeChip.classList.remove('hidden');
-    } else {
-      codeValueEl.textContent = '—';
-      codeChip.classList.add('hidden');
-    }
+    codeValueEl.textContent = '—';
+    codeChip.classList.add('hidden');
   }
   $('#question').textContent = questionValid ? q.q : 'سؤال معتبر در دسترس نیست.';
   const authorWrapper = $('#question-author');


### PR DESCRIPTION
## Summary
- hide the difficulty, question id, coin, and key chips from the quiz header
- treat timed-out questions as unanswered without awarding or deducting points/keys and advance automatically
- stop revealing the correct answer in the post-quiz results list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d594473a448326ab48799ce29ba635