### PR TITLE
Restyle competition lifelines panel

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -431,45 +431,57 @@
         </div>
       </div>
       
-      <!-- Lifelines -->
-      <div class="lifelines-grid">
-        <button id="life-5050" class="lifeline-btn" type="button" aria-label="کمک ۵۰–۵۰">
-          <div class="lifeline-icon"><i class="fas fa-percent"></i></div>
-          <div class="lifeline-details">
-            <div class="lifeline-title">۵۰–۵۰</div>
-            <div class="lifeline-sub">حذف دو گزینهٔ نادرست</div>
-          </div>
-          <div class="lifeline-footer">
-            <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
-            <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> ۵۰–۵۰ فعال شد</div>
-          </div>
-        </button>
-        <button id="life-skip" class="lifeline-btn" type="button" aria-label="پرش به سؤال بعدی">
-          <div class="lifeline-icon"><i class="fas fa-forward"></i></div>
-          <div class="lifeline-details">
-            <div class="lifeline-title">پرش به سؤال بعدی</div>
-            <div class="lifeline-sub">یک‌بار می‌توانی سؤال را رد کنی</div>
-          </div>
-          <div class="lifeline-footer">
-            <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
-            <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> سؤال بعدی فعال شد</div>
-          </div>
-        </button>
-        <button id="life-pause" class="lifeline-btn" type="button" aria-label="افزودن زمان">
-          <div class="lifeline-icon"><i class="fas fa-stopwatch"></i></div>
-          <div class="lifeline-details">
-            <div class="lifeline-title">افزودن ۱۰ ثانیه</div>
-            <div class="lifeline-sub">۱۰ ثانیه زمان بیشتر برای این سؤال</div>
-          </div>
-          <div class="lifeline-footer">
-            <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
-            <div class="lifeline-status hidden"><i class="fas fa-bolt ml-1"></i> ۱۰ ثانیه اضافه شد</div>
-          </div>
-        </button>
-      </div>
-      
       <div id="choices" class="space-y-4"></div>
-      
+
+      <!-- Lifelines -->
+      <section class="lifelines-panel" aria-label="ابزارهای کمکی مسابقه">
+        <div class="lifelines-header">
+          <div class="lifelines-heading">
+            <span class="lifelines-icon"><i class="fas fa-wand-magic-sparkles"></i></span>
+            <div>
+              <div class="lifelines-title-text">ابزارهای کمکی</div>
+              <p class="lifelines-subtitle">با استفاده از کلیدها، شانس بردن هر سؤال را بالاتر ببر.</p>
+            </div>
+          </div>
+          <div class="lifelines-balance" id="lifelines-balance" aria-live="polite"></div>
+        </div>
+        <div class="lifelines-grid">
+          <button id="life-5050" class="lifeline-btn" type="button" aria-label="کمک ۵۰–۵۰">
+            <div class="lifeline-icon"><i class="fas fa-percent"></i></div>
+            <div class="lifeline-details">
+              <div class="lifeline-title">۵۰–۵۰</div>
+              <div class="lifeline-sub">حذف دو گزینهٔ نادرست</div>
+            </div>
+            <div class="lifeline-footer">
+              <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
+              <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> ۵۰–۵۰ فعال شد</div>
+            </div>
+          </button>
+          <button id="life-skip" class="lifeline-btn" type="button" aria-label="پرش به سؤال بعدی">
+            <div class="lifeline-icon"><i class="fas fa-forward"></i></div>
+            <div class="lifeline-details">
+              <div class="lifeline-title">پرش به سؤال بعدی</div>
+              <div class="lifeline-sub">یک‌بار می‌توانی سؤال را رد کنی</div>
+            </div>
+            <div class="lifeline-footer">
+              <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
+              <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> سؤال بعدی فعال شد</div>
+            </div>
+          </button>
+          <button id="life-pause" class="lifeline-btn" type="button" aria-label="افزودن زمان">
+            <div class="lifeline-icon"><i class="fas fa-stopwatch"></i></div>
+            <div class="lifeline-details">
+              <div class="lifeline-title">افزودن ۱۰ ثانیه</div>
+              <div class="lifeline-sub">۱۰ ثانیه زمان بیشتر برای این سؤال</div>
+            </div>
+            <div class="lifeline-footer">
+              <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
+              <div class="lifeline-status hidden"><i class="fas fa-bolt ml-1"></i> ۱۰ ثانیه اضافه شد</div>
+            </div>
+          </button>
+        </div>
+      </section>
+
       <div class="flex flex-col sm:flex-row items-center gap-4">
         <button id="btn-quit" class="w-full sm:flex-1 py-4 rounded-2xl bg-white/10 border border-white/20 hover:bg-white/20 transition flex items-center justify-center gap-2">
           <i class="fas fa-arrow-right"></i> خروج

--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -60,6 +60,11 @@ function animateKeyChip() {
 
 export function updateLifelineStates() {
   const hasKeys = State.lives >= LIFELINE_COST;
+  const balanceEl = $('#lifelines-balance');
+  if (balanceEl) {
+    const keys = Number.isFinite(State.lives) ? Math.max(0, State.lives) : 0;
+    balanceEl.innerHTML = `<i class="fas fa-key"></i><span>${faNum(keys)} کلید در دسترس</span>`;
+  }
   ['life-5050', 'life-skip', 'life-pause'].forEach((id) => {
     const btn = $('#' + id);
     if (!btn) return;

--- a/Iquiz-assets/style.css
+++ b/Iquiz-assets/style.css
@@ -78,35 +78,47 @@
     #community-options .option-row.selected{ border-color:rgba(250,204,21,0.55); background:linear-gradient(135deg, rgba(250,204,21,0.18), rgba(251,191,36,0.12)); box-shadow:0 14px 28px rgba(15,23,42,0.28); }
     #community-options .option-row input.form-input{ background:rgba(15,23,42,0.45); }
     #community-options .option-row input[type="radio"]{ cursor:pointer; }
-    .lifeline-btn{ position:relative; display:flex; flex-direction:column; align-items:center; justify-content:flex-start; gap:.5rem; padding:.8rem .75rem; border-radius:1.2rem; background:linear-gradient(150deg, rgba(255,255,255,0.18), rgba(255,255,255,0.06)); border:1px solid rgba(255,255,255,0.24); box-shadow:0 12px 30px rgba(15,23,42,0.16); transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease; min-height:0; text-align:center; }
+    .lifelines-panel{ margin-top:1.5rem; padding:1.6rem 1.4rem; border-radius:1.8rem; background:linear-gradient(160deg, rgba(15,23,42,0.7), rgba(59,130,246,0.32)); border:1px solid rgba(255,255,255,0.16); box-shadow:0 22px 45px rgba(15,23,42,0.28); display:flex; flex-direction:column; gap:1.25rem; }
+    .lifelines-header{ display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
+    .lifelines-heading{ display:flex; align-items:center; gap:.85rem; }
+    .lifelines-icon{ width:2.4rem; height:2.4rem; border-radius:.9rem; background:linear-gradient(135deg, var(--accent1), var(--accent2)); display:flex; align-items:center; justify-content:center; color:#0f172a; font-size:1.15rem; box-shadow:0 14px 32px rgba(59,130,246,0.35); }
+    .lifelines-title-text{ font-size:1.05rem; font-weight:900; letter-spacing:-0.01em; }
+    .lifelines-subtitle{ margin:0; font-size:.78rem; opacity:.82; line-height:1.7; }
+    .lifelines-balance{ display:flex; align-items:center; gap:.4rem; padding:.45rem .9rem; border-radius:999px; border:1px solid rgba(255,255,255,0.22); background:rgba(15,23,42,0.35); color:#facc15; font-weight:800; font-size:.8rem; min-height:2.1rem; box-shadow:0 10px 25px rgba(15,23,42,0.25); }
+    .lifelines-balance i{ color:#facc15; }
+    .lifelines-balance:empty{ display:none; }
+    .lifeline-btn{ position:relative; display:flex; flex-direction:column; align-items:flex-start; justify-content:flex-start; gap:.65rem; padding:1rem .9rem; border-radius:1.2rem; background:linear-gradient(150deg, rgba(255,255,255,0.18), rgba(255,255,255,0.07)); border:1px solid rgba(255,255,255,0.24); box-shadow:0 12px 30px rgba(15,23,42,0.16); transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease; min-height:0; text-align:right; }
     .lifeline-btn:hover{ transform:translateY(-3px); box-shadow:0 18px 36px rgba(15,23,42,0.2); border-color:rgba(255,255,255,0.3); }
     .lifeline-btn:active{ transform:translateY(-1px); }
     .lifeline-btn:disabled{ opacity:.6; cursor:not-allowed; box-shadow:none; transform:none; border-color:rgba(255,255,255,0.16); }
     .lifeline-icon{ width:2.2rem; height:2.2rem; border-radius:.75rem; display:flex; align-items:center; justify-content:center; font-size:1rem; color:#0f172a; background:linear-gradient(135deg,var(--accent1),var(--accent2)); box-shadow:0 9px 22px rgba(14,116,144,0.26); }
     .lifeline-btn:disabled .lifeline-icon{ background:linear-gradient(135deg, rgba(34,197,94,0.28), rgba(16,185,129,0.24)); color:#d1fae5; box-shadow:none; }
-    .lifeline-details{ display:flex; flex-direction:column; gap:.2rem; }
-    .lifeline-title{ font-weight:800; font-size:.9rem; letter-spacing:-0.01em; }
-    .lifeline-sub{ font-size:.72rem; opacity:.88; line-height:1.35; }
-    .lifeline-footer{ display:flex; flex-direction:column; align-items:center; gap:.24rem; }
+    .lifeline-details{ display:flex; flex-direction:column; gap:.25rem; }
+    .lifeline-title{ font-weight:800; font-size:.92rem; letter-spacing:-0.01em; }
+    .lifeline-sub{ font-size:.72rem; opacity:.9; line-height:1.6; }
+    .lifeline-footer{ display:flex; align-items:center; justify-content:space-between; gap:.6rem; flex-wrap:wrap; width:100%; margin-top:auto; }
     .lifeline-cost{ display:inline-flex; align-items:center; gap:.25rem; padding:.26rem .7rem; border-radius:999px; font-weight:700; font-size:.76rem; background:rgba(17,24,39,0.2); border:1px solid rgba(255,255,255,0.22); color:#facc15; box-shadow:0 8px 20px rgba(15,23,42,0.2); }
     .lifeline-cost i{ color:#facc15; }
     .lifeline-cost.not-enough{ background:rgba(127,29,29,0.34); color:#fecaca; border-color:rgba(248,113,113,0.38); box-shadow:0 0 0 1px rgba(248,113,113,0.3); }
-    .lifeline-status{ font-size:.66rem; font-weight:700; display:flex; align-items:center; gap:.3rem; color:#bbf7d0; background:rgba(34,197,94,0.26); border:1px solid rgba(34,197,94,0.36); border-radius:999px; padding:.24rem .7rem; }
+    .lifeline-status{ font-size:.66rem; font-weight:700; display:flex; align-items:center; gap:.3rem; color:#bbf7d0; background:rgba(34,197,94,0.26); border:1px solid rgba(34,197,94,0.36); border-radius:999px; padding:.24rem .7rem; white-space:nowrap; }
     .lifeline-btn[data-insufficient="true"]{ border-color:rgba(248,113,113,0.38); box-shadow:0 0 0 1px rgba(248,113,113,0.25) inset; }
     .lifeline-btn[data-insufficient="true"] .lifeline-icon{ background:linear-gradient(135deg, rgba(248,113,113,0.35), rgba(239,68,68,0.32)); color:#fff; box-shadow:none; }
     .lifeline-btn[data-insufficient="true"] .lifeline-title{ color:#fee2e2; }
     .lifeline-btn[data-insufficient="true"] .lifeline-sub{ color:rgba(255,255,255,0.78); }
-    .lifelines-grid{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:.7rem; align-items:stretch; }
+    .lifelines-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:1rem; align-items:stretch; width:100%; }
     .lifeline-btn{ width:100%; }
     @media(max-width:639px){
-      .lifelines-grid{ gap:.35rem; padding-inline:.2rem; }
-      .lifeline-btn{ padding:.7rem .55rem; border-radius:1.1rem; min-height:110px; box-shadow:0 6px 18px rgba(15,23,42,0.14); }
+      .lifelines-panel{ padding:1.3rem 1.1rem; border-radius:1.6rem; gap:1rem; }
+      .lifelines-heading{ width:100%; justify-content:center; text-align:center; }
+      .lifelines-header{ justify-content:center; }
+      .lifelines-grid{ grid-template-columns:1fr; gap:.75rem; padding-inline:.1rem; }
+      .lifeline-btn{ padding:.85rem .7rem; border-radius:1.1rem; min-height:0; box-shadow:0 6px 18px rgba(15,23,42,0.14); }
       .lifeline-icon{ width:1.9rem; height:1.9rem; border-radius:.7rem; font-size:.9rem; }
-      .lifeline-title{ font-size:.82rem; }
-      .lifeline-sub{ font-size:.64rem; line-height:1.28; }
-      .lifeline-footer{ gap:.18rem; }
-      .lifeline-cost{ padding:.2rem .5rem; font-size:.66rem; }
-      .lifeline-status{ font-size:.6rem; padding:.2rem .5rem; }
+      .lifeline-title{ font-size:.84rem; }
+      .lifeline-sub{ font-size:.66rem; line-height:1.45; }
+      .lifeline-footer{ gap:.4rem; justify-content:flex-start; }
+      .lifeline-cost{ padding:.2rem .55rem; font-size:.68rem; }
+      .lifeline-status{ font-size:.6rem; padding:.2rem .55rem; }
     }
     @media(min-width:640px){
       .lifelines-grid{ gap:.9rem; }


### PR DESCRIPTION
## Summary
- move the competition lifeline buttons beneath the answer choices inside a dedicated support panel with improved copy
- add modern glassmorphism styling and responsive layout tweaks for the lifeline controls
- surface the available key balance next to the lifelines via the quiz engine updater

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d597032a388326861e2fd1afd65326