### PR TITLE
Remove skip lifeline from quiz interface

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -457,17 +457,6 @@
               <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> ۵۰–۵۰ فعال شد</div>
             </div>
           </button>
-          <button id="life-skip" class="lifeline-btn" type="button" aria-label="پرش به سؤال بعدی">
-            <div class="lifeline-icon"><i class="fas fa-forward"></i></div>
-            <div class="lifeline-details">
-              <div class="lifeline-title">پرش به سؤال بعدی</div>
-              <div class="lifeline-sub">یک‌بار می‌توانی سؤال را رد کنی</div>
-            </div>
-            <div class="lifeline-footer">
-              <div class="lifeline-cost"><i class="fas fa-key"></i><span>۳ کلید</span></div>
-              <div class="lifeline-status hidden"><i class="fas fa-check ml-1"></i> سؤال بعدی فعال شد</div>
-            </div>
-          </button>
           <button id="life-pause" class="lifeline-btn" type="button" aria-label="افزودن زمان">
             <div class="lifeline-icon"><i class="fas fa-stopwatch"></i></div>
             <div class="lifeline-details">

--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -65,7 +65,7 @@ export function updateLifelineStates() {
     const keys = Number.isFinite(State.lives) ? Math.max(0, State.lives) : 0;
     balanceEl.innerHTML = `<i class="fas fa-key"></i><span>${faNum(keys)} کلید در دسترس</span>`;
   }
-  ['life-5050', 'life-skip', 'life-pause'].forEach((id) => {
+  ['life-5050', 'life-pause'].forEach((id) => {
     const btn = $('#' + id);
     if (!btn) return;
     if (btn.disabled) {
@@ -110,7 +110,7 @@ export function markLifelineUsed(id) {
 }
 
 export function resetLifelinesUI() {
-  ['life-5050', 'life-skip', 'life-pause'].forEach((id) => {
+  ['life-5050', 'life-pause'].forEach((id) => {
     const btn = $('#' + id);
     if (!btn) return;
     btn.disabled = false;
@@ -129,12 +129,10 @@ export function resetLifelinesUI() {
 }
 
 let used5050 = false;
-let usedSkip = false;
 let usedTimeBoost = false;
 
 function resetLifelineUsage() {
   used5050 = false;
-  usedSkip = false;
   usedTimeBoost = false;
 }
 
@@ -165,28 +163,6 @@ export function life5050() {
     }
   });
   toast('<i class="fas fa-percent ml-1"></i> دو گزینه حذف شد');
-  SFX.coin();
-}
-
-export function lifeSkip() {
-  if (usedSkip) {
-    toast('پرش فقط یک‌بار مجازه');
-    return;
-  }
-  const cur = State.quiz.list[State.quiz.idx];
-  if (!isValidQuestion(cur)) {
-    toast('سؤال فعلی معتبر نبود و رد شد.');
-    callDependency('nextQuestion');
-    return;
-  }
-  if (!spendLifelineCost()) return;
-  usedSkip = true;
-  markLifelineUsed('life-skip');
-  clearInterval(State.quiz.timer);
-  State.quiz.results.push({ q: cur.q, ok: false, correct: cur.c[cur.a], you: '— (پرش)' });
-  saveState();
-  toast('<i class="fas fa-forward ml-1"></i> به سؤال بعدی رفتی');
-  callDependency('nextQuestion');
   SFX.coin();
 }
 

--- a/Iquiz-assets/src/features/quiz/events.js
+++ b/Iquiz-assets/src/features/quiz/events.js
@@ -1,5 +1,5 @@
 import { $ } from '../../utils/dom.js';
-import { life5050, lifeSkip, lifePause } from './engine.js';
+import { life5050, lifePause } from './engine.js';
 
 const noop = () => {};
 
@@ -13,6 +13,5 @@ export function registerQuizEvents({
   $('#btn-back-results')?.addEventListener('click', onBackToDashboard);
 
   $('#life-5050')?.addEventListener('click', life5050);
-  $('#life-skip')?.addEventListener('click', lifeSkip);
   $('#life-pause')?.addEventListener('click', lifePause);
 }


### PR DESCRIPTION
## Summary
- remove the "skip question" lifeline button from the quiz UI
- drop the associated event wiring and engine logic for the skip lifeline so only supported aids remain

## Testing
- not run (frontend change without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d62ec6a6d083268bd659b2231627cb