### PR TITLE
Fix quiz answer selection and reduce repeats

### DIFF
--- a/Iquiz-assets/src/state/persistence.js
+++ b/Iquiz-assets/src/state/persistence.js
@@ -33,6 +33,15 @@ function loadState(){
       }
     }
 
+    if (!Array.isArray(State.quiz.recentQuestions)) {
+      State.quiz.recentQuestions = [];
+    } else {
+      State.quiz.recentQuestions = State.quiz.recentQuestions
+        .map((key) => (typeof key === 'string' ? key.trim().toLowerCase() : ''))
+        .filter((key) => key.length > 0)
+        .slice(-40);
+    }
+
     const serverState = JSON.parse(localStorage.getItem(SERVER_STORAGE_KEY) || '{}');
     if (serverState.limits) Object.assign(Server.limits, serverState.limits);
     if (!Server.limits.duels) {

--- a/Iquiz-assets/src/state/state.js
+++ b/Iquiz-assets/src/state/state.js
@@ -252,7 +252,8 @@ const State = {
     sessionEarned:0, results:[],
     baseDuration: DEFAULT_QUESTION_TIME,
     maxQuestions: DEFAULT_MAX_QUESTIONS,
-    correctStreak: 0
+    correctStreak: 0,
+    recentQuestions: []
   },
   notifications:[
     { id:'n1', text:'جام هفتگی از ساعت ۲۰:۰۰ شروع می‌شود. آماده‌ای؟', time:'امروز' },


### PR DESCRIPTION
## Summary
- randomize the choice order for each quiz question so the correct answer is no longer locked to the first option
- keep a recent question history and shuffle the fetched set to minimize repeats while still falling back safely when needed
- avoid showing the "No questions available" toast when fallback questions are served successfully and persist the new history state

## Testing
- npm test *(fails: getQuestions normalises and filters invalid documents)*

------
https://chatgpt.com/codex/tasks/task_e_68d631d155908326b8a5e93ed2873578