### PR TITLE
Manage duel referral navigation within bootstrap module

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1007,7 +1007,7 @@
               <button class="btn btn-secondary btn-inline" id="btn-share-referral">
                 <i class="fas fa-share-nodes ml-2"></i> اشتراک‌گذاری فوری
               </button>
-              <button class="btn btn-tertiary btn-inline" type="button" onclick="navTo('duel')">
+              <button class="btn btn-tertiary btn-inline" type="button" id="btn-referral-duel">
                 <i class="fas fa-user-friends ml-2"></i> دعوت به نبرد دو نفره
               </button>
             </div>

--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -5390,7 +5390,12 @@ function leaveGroup(groupId) {
       toast('<i class="fas fa-check-circle ml-2"></i>لینک کپی شد!');
     }
   });
-  
+
+  const referralDuelBtn = document.getElementById('btn-referral-duel');
+  if (referralDuelBtn) {
+    referralDuelBtn.addEventListener('click', () => navTo('duel'));
+  }
+
   // Support & Advertisers Tabs
   $$('.support-tab').forEach(tab => {
     tab.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove the inline navigation handler from the duel referral button and assign it a dedicated id
- register the referral duel button click handler inside the bootstrap module so navigation is managed centrally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d636a9773483269ac59ca27c666e82