### PR TITLE
Update payment modal cancel handling

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -1758,7 +1758,7 @@
     </div>
     
     <div class="payment-actions">
-      <button class="btn glass-dark border-white/20 flex-1" onclick="closePaymentModal()">
+      <button id="payment-cancel-btn" class="btn glass-dark border-white/20 flex-1">
         انصراف
       </button>
       <button id="payment-confirm-btn" class="btn btn-primary flex-1">

--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -5617,6 +5617,10 @@ async function init(){
         }
       });
 
+      $('#payment-cancel-btn')?.addEventListener('click', () => {
+        closePaymentModal();
+      });
+
       logEvent('session_start', {
         screen_width: window.screen.width,
         screen_height: window.screen.height,


### PR DESCRIPTION
## Summary
- assign a dedicated id to the payment modal cancel button in the bot HTML
- register a click handler in bootstrap.js so the cancel button closes the modal without relying on inline onclick attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d637cc17288326b0465d2b13f8b52b