### PR TITLE
Add wallet and subscription API endpoints

### DIFF
--- a/server/src/controllers/subscription.controller.js
+++ b/server/src/controllers/subscription.controller.js
@@ -1,0 +1,45 @@
+const User = require('../models/User');
+
+function extractUserId(req) {
+  if (!req?.user) return null;
+  return req.user._id || req.user.id || req.user.userId || null;
+}
+
+function normalizeExpiry(value) {
+  if (!value) return null;
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+exports.getSubscriptionStatus = async (req, res, next) => {
+  try {
+    const userId = extractUserId(req);
+    if (!userId) {
+      return res.status(401).json({ ok: false, message: 'Unauthorized' });
+    }
+
+    const user = await User.findById(userId).select({ subscription: 1 }).lean();
+    if (!user) {
+      return res.status(404).json({ ok: false, message: 'User not found' });
+    }
+
+    const subscription = user.subscription || {};
+
+    const response = {
+      active: Boolean(subscription.active),
+      plan: subscription.plan ?? null,
+      tier: subscription.tier ?? null,
+      expiry: normalizeExpiry(subscription.expiry),
+      autoRenew: Boolean(subscription.autoRenew)
+    };
+
+    return res.json({ ok: true, data: response });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/controllers/wallet.controller.js
+++ b/server/src/controllers/wallet.controller.js
@@ -1,0 +1,27 @@
+const User = require('../models/User');
+
+function extractUserId(req) {
+  if (!req?.user) return null;
+  return req.user._id || req.user.id || req.user.userId || null;
+}
+
+exports.getWalletBalance = async (req, res, next) => {
+  try {
+    const userId = extractUserId(req);
+    if (!userId) {
+      return res.status(401).json({ ok: false, message: 'Unauthorized' });
+    }
+
+    const user = await User.findById(userId).select({ coins: 1 }).lean();
+    if (!user) {
+      return res.status(404).json({ ok: false, message: 'User not found' });
+    }
+
+    const coinsValue = Number(user.coins);
+    const coins = Number.isFinite(coinsValue) ? coinsValue : 0;
+
+    return res.json({ ok: true, data: { coins } });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -101,6 +101,8 @@ app.use('/api/admin/metrics', require('./routes/admin/metrics'));
 app.use('/api/public', require('./routes/public.routes'));
 app.use('/api/jservice', jserviceRoutes);
 app.use('/api', aiRoutes);
+app.use('/api/wallet', require('./routes/wallet.routes'));
+app.use('/api/subscription', require('./routes/subscription.routes'));
 app.use('/api/payments', require('./routes/payments.routes'));
 app.use('/payments', require('./routes/payments-public.routes'));
 

--- a/server/src/routes/subscription.routes.js
+++ b/server/src/routes/subscription.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const { protect } = require('../middleware/auth');
+const subscriptionController = require('../controllers/subscription.controller');
+
+router.get('/', protect, subscriptionController.getSubscriptionStatus);
+
+module.exports = router;

--- a/server/src/routes/wallet.routes.js
+++ b/server/src/routes/wallet.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const { protect } = require('../middleware/auth');
+const walletController = require('../controllers/wallet.controller');
+
+router.get('/', protect, walletController.getWalletBalance);
+
+module.exports = router;

--- a/server/test/subscriptionController.test.js
+++ b/server/test/subscriptionController.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const subscriptionController = require('../src/controllers/subscription.controller');
+const User = require('../src/models/User');
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function mockFindById(result) {
+  const original = User.findById;
+  let capturedId = null;
+
+  User.findById = (id) => {
+    capturedId = id;
+    return {
+      select() { return this; },
+      lean() { return Promise.resolve(typeof result === 'function' ? result(id) : result); }
+    };
+  };
+
+  return {
+    getCapturedId() {
+      return capturedId;
+    },
+    restore() {
+      User.findById = original;
+    }
+  };
+}
+
+test('getSubscriptionStatus returns stored subscription details', async () => {
+  const expiry = new Date('2030-01-01T00:00:00.000Z');
+  const stub = mockFindById({
+    _id: 'user-2',
+    subscription: {
+      active: true,
+      plan: 'vip-monthly',
+      tier: 'gold',
+      expiry,
+      autoRenew: true
+    }
+  });
+
+  const req = { user: { _id: 'user-2' } };
+  const res = createMockRes();
+
+  try {
+    await subscriptionController.getSubscriptionStatus(req, res, (err) => { throw err || new Error('next should not be called'); });
+
+    assert.strictEqual(stub.getCapturedId(), 'user-2');
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, {
+      ok: true,
+      data: {
+        active: true,
+        plan: 'vip-monthly',
+        tier: 'gold',
+        expiry: expiry.toISOString(),
+        autoRenew: true
+      }
+    });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getSubscriptionStatus returns defaults when subscription is inactive', async () => {
+  const stub = mockFindById({
+    _id: 'user-3',
+    subscription: {
+      active: false
+    }
+  });
+
+  const req = { user: { _id: 'user-3' } };
+  const res = createMockRes();
+
+  try {
+    await subscriptionController.getSubscriptionStatus(req, res, (err) => { throw err || new Error('next should not be called'); });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, {
+      ok: true,
+      data: {
+        active: false,
+        plan: null,
+        tier: null,
+        expiry: null,
+        autoRenew: false
+      }
+    });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getSubscriptionStatus returns 404 for unknown user', async () => {
+  const stub = mockFindById(null);
+
+  const req = { user: { _id: 'missing-user' } };
+  const res = createMockRes();
+
+  try {
+    await subscriptionController.getSubscriptionStatus(req, res, (err) => { throw err || new Error('next should not be called'); });
+
+    assert.strictEqual(res.statusCode, 404);
+    assert.deepStrictEqual(res.body, { ok: false, message: 'User not found' });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getSubscriptionStatus returns 401 when request has no user context', async () => {
+  const res = createMockRes();
+
+  await subscriptionController.getSubscriptionStatus({}, res, (err) => { throw err || new Error('next should not be called'); });
+
+  assert.strictEqual(res.statusCode, 401);
+  assert.deepStrictEqual(res.body, { ok: false, message: 'Unauthorized' });
+});

--- a/server/test/walletController.test.js
+++ b/server/test/walletController.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const walletController = require('../src/controllers/wallet.controller');
+const User = require('../src/models/User');
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function mockFindById(result) {
+  const original = User.findById;
+  let capturedId = null;
+
+  User.findById = (id) => {
+    capturedId = id;
+    return {
+      select() { return this; },
+      lean() { return Promise.resolve(typeof result === 'function' ? result(id) : result); }
+    };
+  };
+
+  return {
+    getCapturedId() {
+      return capturedId;
+    },
+    restore() {
+      User.findById = original;
+    }
+  };
+}
+
+test('getWalletBalance returns coins for the authenticated user', async () => {
+  const stub = mockFindById({ _id: 'user-1', coins: 275 });
+
+  const req = { user: { _id: 'user-1' } };
+  const res = createMockRes();
+
+  try {
+    await walletController.getWalletBalance(req, res, (err) => { throw err || new Error('next should not be called'); });
+
+    assert.strictEqual(stub.getCapturedId(), 'user-1');
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, { ok: true, data: { coins: 275 } });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getWalletBalance returns 404 when user is missing', async () => {
+  const stub = mockFindById(null);
+
+  const req = { user: { _id: 'missing-user' } };
+  const res = createMockRes();
+
+  try {
+    await walletController.getWalletBalance(req, res, (err) => { throw err || new Error('next should not be called'); });
+
+    assert.strictEqual(res.statusCode, 404);
+    assert.deepStrictEqual(res.body, { ok: false, message: 'User not found' });
+  } finally {
+    stub.restore();
+  }
+});
+
+test('getWalletBalance returns 401 when request has no user context', async () => {
+  const res = createMockRes();
+
+  await walletController.getWalletBalance({}, res, (err) => { throw err || new Error('next should not be called'); });
+
+  assert.strictEqual(res.statusCode, 401);
+  assert.deepStrictEqual(res.body, { ok: false, message: 'Unauthorized' });
+});


### PR DESCRIPTION
## Summary
- add protected wallet and subscription route modules mounted under /api
- implement controllers that load the authenticated user to return wallet coins and VIP subscription details
- cover wallet/subscription responses and error scenarios with controller tests

## Testing
- npm test *(fails: questionService existing assertion mismatch)*
- node --test test/walletController.test.js test/subscriptionController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d65a3e542c8326a08cabd79ff1f828