### PR TITLE
Implement Telegram session handshake for WebApp

### DIFF
--- a/Iquiz-assets/src/services/net.js
+++ b/Iquiz-assets/src/services/net.js
@@ -1,10 +1,19 @@
 import { getGuestId } from '../utils/guest.js';
 
+let authToken = '';
+
+export function setAuthToken(token = '') {
+  authToken = token ? String(token) : '';
+}
+
 function buildHeaders(extra = {}) {
   const headers = { ...extra };
   const guestId = getGuestId();
   if (guestId) {
     headers['x-guest-id'] = guestId;
+  }
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
   }
   return headers;
 }
@@ -56,5 +65,5 @@ export async function jpost(url, data, timeoutMs = 12000) {
   }
 }
 
-const Net = { jget, jpost };
+const Net = { jget, jpost, setAuthToken };
 export default Net;

--- a/Iquiz-assets/src/utils/guest.js
+++ b/Iquiz-assets/src/utils/guest.js
@@ -39,3 +39,19 @@ export function refreshGuestId() {
   return getGuestId();
 }
 
+export function setGuestId(nextId = '') {
+  if (!nextId) {
+    return cachedGuestId;
+  }
+
+  cachedGuestId = String(nextId);
+
+  try {
+    localStorage.setItem(STORAGE_KEY, cachedGuestId);
+  } catch (_) {
+    // Ignore write errors.
+  }
+
+  return cachedGuestId;
+}
+


### PR DESCRIPTION
## Summary
- extract Telegram WebApp init data and send it to the new session endpoint
- persist verified Telegram user details, guest identifier, and optional token in state/storage
- expose helpers to update request headers with refreshed guest IDs or auth tokens

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67d22ce408326be01f38fd915eb24