### PR TITLE
Add Telegram WebApp authentication endpoint

### DIFF
--- a/server/src/controllers/telegram.controller.js
+++ b/server/src/controllers/telegram.controller.js
@@ -1,0 +1,100 @@
+const jwt = require('jsonwebtoken');
+
+const env = require('../config/env');
+const logger = require('../config/logger');
+const User = require('../models/User');
+const { verifyTelegramInitData, normalizeTelegramProfile } = require('../services/telegramAuth');
+
+const { jwt: jwtConfig, telegram: telegramConfig } = env;
+
+function signJwt(id) {
+  return jwt.sign({ id }, jwtConfig.secret, { expiresIn: jwtConfig.expiresIn });
+}
+
+function deriveUsername(profile) {
+  const base = profile.telegramUsername || profile.name || `tg_${profile.telegramId}`;
+  if (!base) {
+    return `tg_${Date.now()}`;
+  }
+
+  const sanitized = base
+    .toString()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^\w.-]/g, '')
+    .replace(/_{2,}/g, '_');
+
+  return sanitized || `tg_${profile.telegramId || Date.now()}`;
+}
+
+exports.createSession = async (req, res, next) => {
+  try {
+    if (!telegramConfig.botToken) {
+      return res.status(503).json({ ok: false, message: 'Telegram authentication is not configured' });
+    }
+
+    const initDataInput = typeof req.body?.initData === 'string' ? req.body.initData : req.body;
+    const verification = verifyTelegramInitData(initDataInput, telegramConfig.botToken);
+
+    if (!verification.ok) {
+      logger.warn(`[telegram-auth] Verification failed: ${verification.reason || 'unknown reason'}`);
+      return res.status(401).json({ ok: false, message: 'Invalid init data signature' });
+    }
+
+    const normalized = normalizeTelegramProfile(initDataInput);
+    const profile = normalized.profile;
+
+    if (!profile.telegramId) {
+      return res.status(400).json({ ok: false, message: 'Missing Telegram user identifier' });
+    }
+
+    let user = await User.findOne({ telegramId: profile.telegramId });
+    let isNew = false;
+
+    if (!user) {
+      isNew = true;
+      const username = deriveUsername(profile);
+      user = new User({
+        username,
+        name: profile.name || username,
+        telegramId: profile.telegramId,
+        telegramUsername: profile.telegramUsername || '',
+        avatar: profile.avatar || ''
+      });
+    } else {
+      if (profile.name) {
+        user.name = profile.name;
+      }
+      if (profile.telegramUsername) {
+        user.telegramUsername = profile.telegramUsername;
+      }
+      if (profile.avatar) {
+        user.avatar = profile.avatar;
+      }
+    }
+
+    if (normalized.authDate instanceof Date && Number.isFinite(normalized.authDate.getTime())) {
+      user.lastTelegramAuthAt = normalized.authDate;
+    }
+
+    await user.save();
+
+    const token = signJwt(user._id);
+    res.json({
+      ok: true,
+      token,
+      user: {
+        id: user._id,
+        username: user.username,
+        name: user.name,
+        telegramId: user.telegramId,
+        telegramUsername: user.telegramUsername,
+        avatar: user.avatar,
+        role: user.role
+      },
+      isNew
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,6 +26,7 @@ const app = express();
 // یادآوری: برای اینکه HTML استاتیک (که اسکریپت‌های درون‌خطی دارد) درست کار کند، باید
 // علاوه بر script-src، دستورهای script-src-elem و script-src-attr را هم بازتعریف کنیم؛
 // در غیر اینصورت Helmet برای آن‌ها مقدار «'none'» قرار می‌دهد و اجرای اسکریپت‌ها متوقف می‌شود.
+const telegramOrigins = Array.from(new Set((env.telegram.allowedOrigins || []).filter(Boolean)));
 app.use(helmet({
   contentSecurityPolicy: {
     useDefaults: true,
@@ -36,8 +37,8 @@ app.use(helmet({
       scriptSrcAttr: ["'unsafe-inline'"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://cdnjs.cloudflare.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com", "https://cdnjs.cloudflare.com", "data:"],
-      imgSrc: ["'self'", "data:", "https://i.pravatar.cc"],
-      connectSrc: ["'self'"],
+      imgSrc: ["'self'", "data:", "https://i.pravatar.cc", ...telegramOrigins],
+      connectSrc: ["'self'", ...telegramOrigins],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: []
     }

--- a/server/src/routes/public.routes.js
+++ b/server/src/routes/public.routes.js
@@ -5,6 +5,7 @@ const Category = require('../models/Category');
 const questionsController = require('../controllers/questions.controller');
 const AdModel = require('../models/Ad');
 const QuestionService = require('../services/questionService');
+const telegramController = require('../controllers/telegram.controller');
 const { resolveCategory } = require('../config/categories');
 const { recordAnswerEvent } = require('../controllers/answers');
 const {
@@ -139,6 +140,7 @@ router.get('/config', (req, res) => {
 });
 
 router.post('/questions/submit', questionsController.submitPublic);
+router.post('/telegram/session', telegramController.createSession);
 
 router.post('/answers', async (req, res, next) => {
   try {

--- a/server/src/services/telegramAuth.js
+++ b/server/src/services/telegramAuth.js
@@ -1,0 +1,165 @@
+const crypto = require('crypto');
+
+function toSearchParams(initDataUnsafe) {
+  if (!initDataUnsafe) {
+    return new URLSearchParams();
+  }
+
+  if (initDataUnsafe instanceof URLSearchParams) {
+    return initDataUnsafe;
+  }
+
+  if (typeof initDataUnsafe === 'string') {
+    const normalized = initDataUnsafe.trim().replace(/^\?/, '');
+    return new URLSearchParams(normalized);
+  }
+
+  if (typeof initDataUnsafe === 'object') {
+    if (typeof initDataUnsafe.initData === 'string') {
+      return toSearchParams(initDataUnsafe.initData);
+    }
+
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(initDataUnsafe)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          if (entry === undefined || entry === null) continue;
+          params.append(key, typeof entry === 'string' ? entry : JSON.stringify(entry));
+        }
+        continue;
+      }
+
+      if (typeof value === 'object') {
+        params.append(key, JSON.stringify(value));
+      } else {
+        params.append(key, String(value));
+      }
+    }
+    return params;
+  }
+
+  return new URLSearchParams();
+}
+
+function paramsToObject(params) {
+  const payload = {};
+  for (const [key, value] of params.entries()) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      if (Array.isArray(payload[key])) {
+        payload[key].push(value);
+      } else {
+        payload[key] = [payload[key], value];
+      }
+    } else {
+      payload[key] = value;
+    }
+  }
+  return payload;
+}
+
+function buildDataCheckString(params) {
+  const pairs = [];
+  for (const [key, value] of params.entries()) {
+    if (key === 'hash') continue;
+    pairs.push([key, value]);
+  }
+
+  pairs.sort((a, b) => a[0].localeCompare(b[0]));
+  return pairs.map(([key, value]) => `${key}=${value}`).join('\n');
+}
+
+function verifyTelegramInitData(initDataUnsafe, botToken) {
+  const params = toSearchParams(initDataUnsafe);
+  const payload = paramsToObject(params);
+  const hash = params.get('hash');
+
+  if (!botToken) {
+    return { ok: false, reason: 'BOT_TOKEN_MISSING', payload };
+  }
+
+  if (!hash) {
+    return { ok: false, reason: 'HASH_MISSING', payload };
+  }
+
+  const dataCheckString = buildDataCheckString(params);
+  const secretKey = crypto.createHash('sha256').update(botToken).digest();
+  const signature = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+
+  let provided;
+  try {
+    provided = Buffer.from(hash, 'hex');
+  } catch (error) {
+    return { ok: false, reason: 'HASH_INVALID', payload, dataCheckString };
+  }
+
+  const expected = Buffer.from(signature, 'hex');
+  const valid =
+    provided.length === expected.length &&
+    expected.length > 0 &&
+    crypto.timingSafeEqual(provided, expected);
+
+  return {
+    ok: valid,
+    reason: valid ? undefined : 'SIGNATURE_MISMATCH',
+    payload,
+    dataCheckString
+  };
+}
+
+function parseTelegramUser(userRaw) {
+  if (!userRaw) return null;
+
+  if (typeof userRaw === 'string') {
+    try {
+      return JSON.parse(userRaw);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  if (typeof userRaw === 'object') {
+    return userRaw;
+  }
+
+  return null;
+}
+
+function normalizeTelegramProfile(initDataUnsafe) {
+  const params = toSearchParams(initDataUnsafe);
+  const payload = paramsToObject(params);
+  const userData = parseTelegramUser(payload.user);
+
+  const id = userData?.id;
+  const telegramId = id !== undefined && id !== null ? String(id) : '';
+  const telegramUsername = typeof userData?.username === 'string' ? userData.username.trim() : '';
+  const firstName = typeof userData?.first_name === 'string' ? userData.first_name.trim() : '';
+  const lastName = typeof userData?.last_name === 'string' ? userData.last_name.trim() : '';
+  const languageCode = typeof userData?.language_code === 'string' ? userData.language_code.trim() : '';
+  const avatar = typeof userData?.photo_url === 'string' ? userData.photo_url.trim() : '';
+  const authDateSeconds = typeof payload.auth_date === 'string' ? Number.parseInt(payload.auth_date, 10) : Number(payload.auth_date);
+  const authDate = Number.isFinite(authDateSeconds) ? new Date(authDateSeconds * 1000) : null;
+
+  let name = `${firstName} ${lastName}`.trim();
+  if (!name) {
+    name = telegramUsername || firstName || lastName;
+  }
+
+  return {
+    payload,
+    profile: {
+      telegramId,
+      telegramUsername,
+      name,
+      avatar,
+      languageCode
+    },
+    user: userData,
+    authDate
+  };
+}
+
+module.exports = {
+  verifyTelegramInitData,
+  normalizeTelegramProfile
+};

--- a/server/test/telegramAuth.test.js
+++ b/server/test/telegramAuth.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+
+const { verifyTelegramInitData, normalizeTelegramProfile } = require('../src/services/telegramAuth');
+
+function createInitData(botToken, payload) {
+  const params = new URLSearchParams();
+  Object.entries(payload).forEach(([key, value]) => {
+    params.append(key, value);
+  });
+
+  const pairs = Array.from(params.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const dataCheckString = pairs.map(([key, value]) => `${key}=${value}`).join('\n');
+  const secretKey = crypto.createHash('sha256').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
+
+test('verifyTelegramInitData accepts valid signatures and normalization works', () => {
+  const botToken = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
+  const user = {
+    id: 42,
+    first_name: 'Jane',
+    last_name: 'Doe',
+    username: 'jane_doe',
+    photo_url: 'https://t.me/i/userpic/42.jpg',
+    language_code: 'en'
+  };
+  const payload = {
+    auth_date: '1700000000',
+    query_id: 'AAE123456789',
+    user: JSON.stringify(user)
+  };
+  const initData = createInitData(botToken, payload);
+
+  const verification = verifyTelegramInitData(initData, botToken);
+  assert.ok(verification.ok, 'expected signature to be valid');
+  assert.strictEqual(verification.payload.user, payload.user);
+
+  const normalized = normalizeTelegramProfile(initData);
+  assert.strictEqual(normalized.profile.telegramId, '42');
+  assert.strictEqual(normalized.profile.telegramUsername, 'jane_doe');
+  assert.strictEqual(normalized.profile.name, 'Jane Doe');
+  assert.strictEqual(normalized.profile.avatar, 'https://t.me/i/userpic/42.jpg');
+  assert.strictEqual(normalized.profile.languageCode, 'en');
+  assert.ok(normalized.authDate instanceof Date);
+});
+
+test('verifyTelegramInitData rejects invalid signatures', () => {
+  const botToken = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
+  const payload = {
+    auth_date: '1700000000',
+    query_id: 'AAE123456789',
+    user: JSON.stringify({ id: 1, first_name: 'Jane' })
+  };
+  const initData = createInitData(botToken, payload);
+  const tampered = initData.replace(/hash=[^&]+/, 'hash=deadbeef');
+
+  const verification = verifyTelegramInitData(tampered, botToken);
+  assert.strictEqual(verification.ok, false);
+  assert.strictEqual(verification.reason, 'SIGNATURE_MISMATCH');
+});

--- a/server/test/telegramController.test.js
+++ b/server/test/telegramController.test.js
@@ -1,0 +1,146 @@
+const test = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+
+process.env.JWT_SECRET = 'test-secret';
+process.env.TELEGRAM_BOT_TOKEN = 'bot-token:test';
+
+delete require.cache[require.resolve('../src/config/env')];
+const env = require('../src/config/env');
+const telegramController = require('../src/controllers/telegram.controller');
+const User = require('../src/models/User');
+
+function buildInitData(userPayload = {}) {
+  const user = {
+    id: 555,
+    first_name: 'Alice',
+    last_name: 'Example',
+    username: 'alice_example',
+    photo_url: 'https://t.me/i/userpic/555.jpg',
+    ...userPayload
+  };
+
+  const params = new URLSearchParams();
+  params.set('auth_date', '1700000500');
+  params.set('query_id', 'AAE123456');
+  params.set('user', JSON.stringify(user));
+
+  const pairs = Array.from(params.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const dataCheckString = pairs.map(([key, value]) => `${key}=${value}`).join('\n');
+  const secretKey = crypto.createHash('sha256').update(env.telegram.botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+
+  return params.toString();
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test('createSession creates a new Telegram user', async () => {
+  const initData = buildInitData({ id: 1001, username: 'new_user' });
+  const req = { body: { initData } };
+  const res = createMockRes();
+
+  const originalFindOne = User.findOne;
+  const originalSave = User.prototype.save;
+  const created = [];
+
+  User.findOne = async () => null;
+  User.prototype.save = async function saveStub() {
+    created.push(this);
+    return this;
+  };
+
+  try {
+    await telegramController.createSession(req, res, (err) => { throw err; });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body.ok);
+    assert.strictEqual(res.body.isNew, true);
+    assert.strictEqual(created.length, 1);
+    assert.strictEqual(created[0].telegramId, '1001');
+    assert.strictEqual(created[0].telegramUsername, 'new_user');
+
+    const decoded = jwt.verify(res.body.token, env.jwt.secret);
+    assert.strictEqual(String(decoded.id), String(created[0]._id));
+    assert.strictEqual(res.body.user.telegramId, '1001');
+    assert.strictEqual(res.body.user.telegramUsername, 'new_user');
+  } finally {
+    User.findOne = originalFindOne;
+    User.prototype.save = originalSave;
+  }
+});
+
+test('createSession updates existing Telegram user', async () => {
+  const existing = new User({
+    username: 'existing_user',
+    name: 'Existing User',
+    telegramId: '2002',
+    telegramUsername: 'old_username',
+    avatar: 'https://old.example/avatar.png'
+  });
+  existing.isNew = false;
+
+  const initData = buildInitData({
+    id: 2002,
+    username: 'new_username',
+    first_name: 'Updated',
+    last_name: 'Name',
+    photo_url: 'https://t.me/i/userpic/updated.jpg'
+  });
+
+  const req = { body: { initData } };
+  const res = createMockRes();
+
+  const originalFindOne = User.findOne;
+  User.findOne = async () => existing;
+
+  const saved = [];
+  existing.save = async function saveStub() {
+    saved.push({
+      name: this.name,
+      telegramUsername: this.telegramUsername,
+      avatar: this.avatar
+    });
+    return this;
+  };
+
+  try {
+    await telegramController.createSession(req, res, (err) => { throw err; });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body.ok);
+    assert.strictEqual(res.body.isNew, false);
+    assert.strictEqual(saved.length, 1);
+    assert.strictEqual(existing.name, 'Updated Name');
+    assert.strictEqual(existing.telegramUsername, 'new_username');
+    assert.strictEqual(existing.avatar, 'https://t.me/i/userpic/updated.jpg');
+  } finally {
+    User.findOne = originalFindOne;
+  }
+});
+
+test('createSession rejects invalid signature', async () => {
+  const initData = 'query_id=AAE123&user=%7B%22id%22%3A1%7D&hash=deadbeef';
+  const req = { body: { initData } };
+  const res = createMockRes();
+
+  await telegramController.createSession(req, res, (err) => { throw err; });
+
+  assert.strictEqual(res.statusCode, 401);
+  assert.strictEqual(res.body.ok, false);
+});


### PR DESCRIPTION
## Summary
- expose Telegram configuration derived from environment variables and extend security policies for web app origins
- add Telegram init data verification/normalization helpers and a public session controller that upserts users with telegram metadata
- update the user model for Telegram identifiers and cover the new flow with service/controller tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67e3a82208326a2dbcf9260370643