### PR TITLE
Add authenticated endpoint to reset user daily limits

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -97,6 +97,7 @@ app.use('/api/ads', require('./routes/ads.routes'));
 app.use('/api/analytics', require('./routes/analytics.routes'));
 app.use('/api/group-battles', require('./routes/group-battles.routes'));
 app.use('/api/duels', require('./routes/duels.routes'));
+app.use('/api/limits', require('./routes/limits.routes'));
 app.use('/api/admin/questions', require('./routes/admin/questions'));
 app.use('/api/admin/metrics', require('./routes/admin/metrics'));
 app.use('/api/admin/shop', require('./routes/admin/shop'));

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -2,6 +2,18 @@ const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const { isEmail } = require('validator');
 
+const limitStateSchema = new mongoose.Schema({
+  used: { type: Number, default: 0 },
+  lastReset: { type: Date, default: () => new Date(0) },
+  lastRecovery: { type: Date, default: () => new Date(0) }
+}, { _id: false });
+
+const defaultLimitState = () => ({
+  used: 0,
+  lastReset: new Date(0),
+  lastRecovery: new Date(0)
+});
+
 const userSchema = new mongoose.Schema(
   {
     username: { type: String, required: true, trim: true },
@@ -41,6 +53,13 @@ const userSchema = new mongoose.Schema(
       expiry: { type: Date, default: null },
       autoRenew: { type: Boolean, default: false },
       lastTransaction: { type: mongoose.Schema.Types.ObjectId, ref: 'Payment', default: null }
+    },
+    limits: {
+      matches: { type: limitStateSchema, default: defaultLimitState },
+      duels: { type: limitStateSchema, default: defaultLimitState },
+      lives: { type: limitStateSchema, default: defaultLimitState },
+      groupBattles: { type: limitStateSchema, default: defaultLimitState },
+      energy: { type: limitStateSchema, default: defaultLimitState }
     }
   },
   { timestamps: true }

--- a/server/src/routes/limits.routes.js
+++ b/server/src/routes/limits.routes.js
@@ -1,0 +1,45 @@
+const router = require('express').Router();
+const { protect } = require('../middleware/auth');
+const User = require('../models/User');
+
+const LIMIT_KEYS = ['matches', 'duels', 'lives', 'groupBattles', 'energy'];
+
+function getStartOfToday() {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+router.post('/reset', protect, async (req, res, next) => {
+  try {
+    const userId = req.user?._id || req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
+    }
+
+    const startOfToday = getStartOfToday();
+    const set = {};
+
+    for (const key of LIMIT_KEYS) {
+      set[`limits.${key}.used`] = 0;
+      set[`limits.${key}.lastReset`] = new Date(startOfToday);
+      set[`limits.${key}.lastRecovery`] = new Date(startOfToday);
+    }
+
+    const updated = await User.findByIdAndUpdate(
+      userId,
+      { $set: set },
+      { new: true, runValidators: false }
+    );
+
+    if (!updated) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- register a new /api/limits route in the server entrypoint
- add an authenticated POST /reset handler that zeroes user limit usage and refreshes reset timestamps
- extend the User schema with persisted daily limit state for matches, duels, lives, group battles, and energy

## Testing
- Not run (MongoDB is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d685940fb0832691f5628fa266c49e