### PR TITLE
Add public analytics event ingestion endpoint

### DIFF
--- a/server/src/models/AnalyticsEvent.js
+++ b/server/src/models/AnalyticsEvent.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const analyticsEventSchema = new Schema({
+  name: { type: String, required: true, trim: true },
+  occurredAt: { type: Date, required: true },
+  userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+  guestId: { type: String, trim: true, default: null },
+  metadata: { type: Schema.Types.Mixed, default: null },
+  userAgent: { type: String, default: null },
+  clientIp: { type: String, default: null },
+  receivedAt: { type: Date, default: Date.now }
+}, {
+  minimize: false
+});
+
+module.exports = mongoose.models.AnalyticsEvent
+  || mongoose.model('AnalyticsEvent', analyticsEventSchema);

--- a/server/src/routes/analytics.routes.js
+++ b/server/src/routes/analytics.routes.js
@@ -2,6 +2,9 @@ const router = require('express').Router();
 const { protect, adminOnly } = require('../middleware/auth');
 const ctrl = require('../controllers/analytics.controller');
 
+router.post('/', ctrl.recordEvent);
+router.post('/events', ctrl.recordEvent);
+
 router.use(protect, adminOnly);
 router.get('/dashboard', ctrl.dashboard);
 


### PR DESCRIPTION
## Summary
- add an AnalyticsEvent mongoose model to store captured analytics events
- implement a public analytics controller that validates incoming payloads, saves events when Mongo is available, and logs otherwise
- expose POST /api/analytics and /api/analytics/events without admin protection while keeping the dashboard route restricted

## Testing
- `node - <<'NODE' ...` (sample request to POST /api/analytics returning HTTP 201)


------
https://chatgpt.com/codex/tasks/task_e_68d687fecc708326b3069664c8536c9e