### PR TITLE
Simplify VIP subscription management and storefront

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -3554,7 +3554,7 @@
                     <i class="fa-solid fa-crown text-amber-300"></i>
                     <span>مدیریت عضویت VIP</span>
                   </h3>
-                  <p class="text-sm text-white/70">اشتراک ویژه را با کنترل کامل قیمت‌گذاری، مزایا و اتوماسیون پرداخت هدایت کنید.</p>
+                  <p class="text-sm text-white/70">تمام تنظیمات پلن واحد VIP را یکجا مدیریت کنید؛ قیمت، دوره و مزایا فقط با چند فیلد ساده قابل ویرایش است.</p>
                 </div>
                 <div class="flex items-center gap-3">
                   <span class="text-xs font-bold tracking-widest text-emerald-300" data-vip-status-label>فعال</span>
@@ -3639,83 +3639,26 @@
                       </label>
                     </div>
                   </div>
-                  <div class="space-y-4" data-vip-plans-editor>
+                <div class="space-y-4" data-vip-plans-editor>
                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                       <div>
                         <h4 class="text-sm font-semibold text-white flex items-center gap-2">
                           <i class="fa-solid fa-layer-group text-amber-300"></i>
-                          <span>پلن‌های اشتراک VIP</span>
+                          <span>پلن اشتراک VIP</span>
                         </h4>
-                        <p class="text-xs text-white/60 mt-1">قیمت، مزایا و CTA هر پلن را مدیریت کنید تا تجربه فروش حرفه‌ای‌تری ارائه شود.</p>
+                        <p class="text-xs text-white/60 mt-1">فقط یک پلن VIP فعال است؛ قیمت و مزایا را از همین فرم ساده مدیریت کنید.</p>
                       </div>
                       <span class="text-xs text-white/50">قیمت‌ها بر اساس واحد انتخابی فروشگاه نمایش داده می‌شوند.</span>
                     </div>
-                    <div class="grid gap-4 xl:grid-cols-2" data-vip-plan-list>
-                      <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-4" data-vip-plan-card data-vip-plan-tier="lite" data-vip-plan-default-name="وی‌آی‌پی لایت" data-vip-plan-order="1">
-                        <div class="flex items-start justify-between gap-3">
-                          <div>
-                            <div class="text-sm font-semibold text-white/80 flex items-center gap-2">
-                              <i class="fa-solid fa-crown text-amber-300"></i>
-                              <span data-vip-plan-title>وی‌آی‌پی لایت</span>
-                            </div>
-                            <p class="text-xs text-white/50 mt-1">پلن شروع سریع برای کاربران تازه‌وارد.</p>
-                          </div>
-                          <label class="toggle text-xs">
-                            <input type="checkbox" data-vip-plan-active data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
-                            <span class="toggle-label" data-toggle-text>فعال</span>
-                          </label>
-                        </div>
-                        <div class="grid gap-4 sm:grid-cols-2">
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">عنوان نمایشی</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="displayName" value="وی‌آی‌پی لایت" placeholder="مثال: اشتراک طلایی">
-                          </div>
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">قیمت (تومان)</label>
-                            <input type="number" min="0" class="form-input text-sm" data-vip-plan-field="price" value="99000">
-                          </div>
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">دوره صورتحساب</label>
-                            <select class="form-input text-sm" data-vip-plan-field="period">
-                              <option value="هفتگی">هفتگی</option>
-                              <option value="ماهانه" selected>ماهانه</option>
-                              <option value="سه‌ماهه">سه‌ماهه</option>
-                              <option value="سالانه">سالانه</option>
-                            </select>
-                          </div>
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">متن دکمه</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="buttonText" value="شروع اشتراک" placeholder="مثال: شروع اشتراک">
-                          </div>
-                        </div>
-                        <div class="grid gap-4 sm:grid-cols-2">
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">برچسب تبلیغاتی</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="badge" value="شروع هوشمند" placeholder="مثال: پیشنهاد ویژه">
-                          </div>
-                          <div class="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-                            <span class="text-xs text-white/60">نمایش به عنوان پلن پیشنهادی</span>
-                            <label class="toggle text-xs">
-                              <input type="checkbox" data-vip-plan-featured data-toggle-on="بله" data-toggle-off="خیر">
-                              <span class="toggle-label" data-toggle-text>خیر</span>
-                            </label>
-                          </div>
-                        </div>
-                        <div>
-                          <label class="block text-xs text-white/60 mb-1">لیست مزایا (هر خط یک مورد)</label>
-                          <textarea rows="3" class="form-input text-sm" data-vip-plan-field="benefits">حذف تبلیغات بنری
-دو برابر محدودیت روزانه مسابقه/کلید</textarea>
-                          <p class="text-xs text-white/50 mt-1">می‌توانید از گلوله‌گذاری خودکار برای نمایش در فروشگاه استفاده کنید.</p>
-                        </div>
-                      </div>
-                      <div class="rounded-2xl border border-amber-200/40 bg-gradient-to-br from-amber-500/20 via-rose-500/10 to-indigo-600/20 p-4 space-y-4" data-vip-plan-card data-vip-plan-tier="pro" data-vip-plan-default-name="وی‌آی‌پی پرو" data-vip-plan-order="2">
+                    <div class="grid gap-4" data-vip-plan-list>
+                      <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-4" data-vip-plan-card data-vip-plan-tier="standard" data-vip-plan-default-name="اشتراک VIP" data-vip-plan-order="1">
                         <div class="flex items-start justify-between gap-3">
                           <div>
                             <div class="text-sm font-semibold text-white flex items-center gap-2">
-                              <i class="fa-solid fa-crown text-yellow-300"></i>
-                              <span data-vip-plan-title>وی‌آی‌پی پرو</span>
+                              <i class="fa-solid fa-crown text-amber-300"></i>
+                              <span data-vip-plan-title>اشتراک VIP</span>
                             </div>
-                            <p class="text-xs text-white/60 mt-1">پیشنهاد حرفه‌ای با حداکثر مزایا و پشتیبانی.</p>
+                            <p class="text-xs text-white/60 mt-1">پلن واحد برای همه کاربران ویژه.</p>
                           </div>
                           <label class="toggle text-xs">
                             <input type="checkbox" data-vip-plan-active data-toggle-on="فعال" data-toggle-off="غیرفعال" checked>
@@ -3725,11 +3668,11 @@
                         <div class="grid gap-4 sm:grid-cols-2">
                           <div>
                             <label class="block text-xs text-white/60 mb-1">عنوان نمایشی</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="displayName" value="وی‌آی‌پی پرو" placeholder="مثال: اشتراک حرفه‌ای">
+                            <input type="text" class="form-input text-sm" data-vip-plan-field="displayName" value="اشتراک VIP" placeholder="مثال: اشتراک ویژه">
                           </div>
                           <div>
                             <label class="block text-xs text-white/60 mb-1">قیمت (تومان)</label>
-                            <input type="number" min="0" class="form-input text-sm" data-vip-plan-field="price" value="199000">
+                            <input type="number" min="0" class="form-input text-sm" data-vip-plan-field="price" value="149000">
                           </div>
                           <div>
                             <label class="block text-xs text-white/60 mb-1">دوره صورتحساب</label>
@@ -3742,36 +3685,23 @@
                           </div>
                           <div>
                             <label class="block text-xs text-white/60 mb-1">متن دکمه</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="buttonText" value="ارتقا به پرو" placeholder="مثال: ارتقا به پرو">
-                          </div>
-                        </div>
-                        <div class="grid gap-4 sm:grid-cols-2">
-                          <div>
-                            <label class="block text-xs text-white/60 mb-1">برچسب تبلیغاتی</label>
-                            <input type="text" class="form-input text-sm" data-vip-plan-field="badge" value="حرفه‌ای‌ها" placeholder="مثال: محبوب‌ترین">
-                          </div>
-                          <div class="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-                            <span class="text-xs text-white/60">نمایش به عنوان پلن پیشنهادی</span>
-                            <label class="toggle text-xs">
-                              <input type="checkbox" data-vip-plan-featured data-toggle-on="بله" data-toggle-off="خیر" checked>
-                              <span class="toggle-label" data-toggle-text>بله</span>
-                            </label>
+                            <input type="text" class="form-input text-sm" data-vip-plan-field="buttonText" value="خرید اشتراک" placeholder="مثال: فعال‌سازی سریع">
                           </div>
                         </div>
                         <div>
-                          <label class="block text-xs text-white/60 mb-1">لیست مزایا (هر خط یک مورد)</label>
+                          <label class="block text-xs text-white/60 mb-1">مزایا (هر خط یک مورد)</label>
                           <textarea rows="3" class="form-input text-sm" data-vip-plan-field="benefits">حذف تمام تبلیغات
-سه برابر محدودیت روزانه مسابقه/کلید
-جوایز و ماموریت‌های اختصاصی</textarea>
-                          <p class="text-xs text-white/50 mt-1">برای جدا کردن مزایا از کلید Enter استفاده کنید.</p>
+دو برابر شدن محدودیت‌های روزانه
+پشتیبانی اولویت‌دار</textarea>
+                          <p class="text-xs text-white/50 mt-1">مزایا دقیقا همان مواردی هستند که در فروشگاه نمایش داده می‌شوند.</p>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div>
-                    <label class="block text-xs text-white/70 mb-1">توضیحات اختصاصی VIP</label>
-                    <textarea id="shop-vip-benefits" rows="2" class="form-input text-sm" placeholder="مثال: تحلیل اختصاصی عملکرد و مسابقات هفتگی">دسترسی به رویدادهای اختصاصی و تحلیل عملکرد هفتگی.</textarea>
-                    <p class="text-xs text-white/50 mt-1">این متن به‌عنوان توضیح تکمیلی زیر پلن‌های اشتراک نمایش داده می‌شود.</p>
+                    <label class="block text-xs text-white/70 mb-1">توضیح کوتاه برای نمایش در فروشگاه</label>
+                    <textarea id="shop-vip-benefits" rows="2" class="form-input text-sm" placeholder="مثال: حذف تبلیغات و باز شدن محدودیت‌ها">دسترسی به رویدادهای اختصاصی و تحلیل عملکرد هفتگی.</textarea>
+                    <p class="text-xs text-white/50 mt-1">این متن به عنوان توضیح تکمیلی زیر کارت اشتراک در فروشگاه نمایش داده می‌شود.</p>
                   </div>
                 </div>
                 <div class="space-y-5 lg:col-span-2">
@@ -3798,27 +3728,8 @@
                     </div>
                     <p class="text-xs text-white/70 leading-6" data-vip-preview-note>دسترسی به رویدادهای اختصاصی و تحلیل عملکرد هفتگی.</p>
                   </div>
-                  <div class="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-3">
-                    <div class="flex items-center justify-between text-xs text-white/60">
-                      <span>پلن‌های فعال</span>
-                      <span class="text-sm font-bold text-white" data-vip-metric="plans">۲ پلن</span>
-                    </div>
-                    <div class="flex items-center justify-between text-xs text-white/60">
-                      <span>مزایای فعال</span>
-                      <span class="text-sm font-bold text-white" data-vip-metric="perks">۳</span>
-                    </div>
-                    <div class="flex items-center justify-between text-xs text-white/60">
-                      <span>دوره آزمایشی</span>
-                      <span class="text-sm font-bold text-white" data-vip-metric="trial">۳ روز</span>
-                    </div>
-                    <div class="flex items-center justify-between text-xs text-white/60">
-                      <span>ظرفیت همزمان</span>
-                      <span class="text-sm font-bold text-white" data-vip-metric="slots">۱۵۰ نفر</span>
-                    </div>
-                    <div class="flex items-center justify-between text-xs text-white/60">
-                      <span>اتوماسیون</span>
-                      <span class="text-xs font-bold text-white" data-vip-metric="automation">تمدید خودکار + تایید فوری</span>
-                    </div>
+                  <div class="rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-white/70 leading-6">
+                    مدیریت VIP ساده شده است؛ فقط همین پلن برای فروش در اپ نمایش داده می‌شود.
                   </div>
                 </div>
               </div>

--- a/Admin-Panel.js
+++ b/Admin-Panel.js
@@ -7027,7 +7027,7 @@ function updateShopSummary() {
       shopSummaryElements.vip.textContent = 'غیرفعال';
     } else {
       const planLabel = vipState.planCount
-        ? `${formatNumberFa(vipState.planCount)} پلن`
+        ? (vipState.planCount === 1 ? 'پلن واحد' : `${formatNumberFa(vipState.planCount)} پلن`)
         : 'بدون پلن';
       let priceLabel = '';
       if (vipState.cheapestPrice > 0) {

--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -646,16 +646,24 @@
       <!-- VIP -->
       <div class="glass-dark rounded-2xl p-5 card-hover" data-shop-section="vip-intro">
         <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 text-center sm:text-right">
-          <div class="flex items-center gap-4">
+          <div class="flex items-center gap-4 text-right">
             <div class="w-14 h-14 rounded-full bg-gradient-to-r from-yellow-400 to-orange-500 flex items-center justify-center">
               <i class="fas fa-crown text-white text-xl"></i>
             </div>
-            <div>
+            <div class="space-y-2">
               <div class="font-bold text-lg">اشتراک VIP</div>
-              <div class="text-sm opacity-80 mt-1">حذف تبلیغات • سقف روزانه بیشتر • امتیاز اضافه</div>
+              <div class="text-sm opacity-80" data-shop-vip-benefits>حذف تبلیغات • محدودیت‌های بیشتر • پشتیبانی ویژه</div>
+              <div class="text-xs opacity-70" data-shop-vip-price>شروع از —</div>
             </div>
           </div>
-          <button id="btn-open-vip" class="btn btn-tertiary w-full sm:w-auto px-4 text-sm"><i class="fas fa-crown ml-1"></i> مشاهده پلن‌ها</button>
+          <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+            <button id="btn-buy-vip" class="btn btn-primary w-full sm:w-auto px-4 text-sm" data-vip-plan-button>
+              <i class="fas fa-check ml-1"></i> خرید اشتراک
+            </button>
+            <button id="btn-open-vip" class="btn btn-tertiary w-full sm:w-auto px-4 text-sm">
+              <i class="fas fa-crown ml-1"></i> جزئیات اشتراک
+            </button>
+          </div>
         </div>
       </div>
 

--- a/Iquiz-assets/src/config/remote-config.js
+++ b/Iquiz-assets/src/config/remote-config.js
@@ -27,34 +27,20 @@ export const RemoteConfig = {
     ],
 
     vip: {
-      lite: {
-        id:'vip_lite',
-        displayName:'وی‌آی‌پی لایت',
-        priceToman: 99_000,
-        priceCents:299,
+      standard: {
+        id:'vip_standard',
+        displayName:'اشتراک VIP',
+        priceToman: 149_000,
+        priceCents:499,
         period:'ماهانه',
-        buttonText:'شروع اشتراک',
-        benefits:[
-          'حذف تبلیغات بنری',
-          'دو برابر محدودیت روزانه مسابقه/کلید'
-        ],
-        order:1,
-        badge:'شروع هوشمند'
-      },
-      pro:  {
-        id:'vip_pro',
-        displayName:'وی‌آی‌پی پرو',
-        priceToman: 199_000,
-        priceCents:599,
-        period:'ماهانه',
-        buttonText:'ارتقا به پرو',
+        buttonText:'خرید اشتراک',
         benefits:[
           'حذف تمام تبلیغات',
-          'سه برابر محدودیت روزانه مسابقه/کلید',
-          'جوایز و ماموریت‌های اختصاصی'
+          'دو برابر شدن محدودیت‌های روزانه',
+          'پشتیبانی اولویت‌دار'
         ],
-        order:2,
-        badge:'حرفه‌ای‌ها'
+        order:1,
+        badge:'اشتراک ویژه'
       }
     },
 
@@ -70,38 +56,25 @@ export const RemoteConfig = {
     sections: { hero: true, keys: true, wallet: true, vip: true },
     vipPlans: [
       {
-        id: 'vip_lite',
-        tier: 'lite',
-        displayName: 'وی‌آی‌پی لایت',
-        price: 99_000,
+        id: 'vip_standard',
+        tier: 'standard',
+        displayName: 'اشتراک VIP',
+        price: 149_000,
         period: 'ماهانه',
-        buttonText: 'شروع اشتراک',
-        benefits: ['حذف تبلیغات بنری', 'دو برابر محدودیت روزانه مسابقه/کلید'],
-        badge: 'شروع هوشمند',
-        featured: false,
-        order: 1,
-        active: true
-      },
-      {
-        id: 'vip_pro',
-        tier: 'pro',
-        displayName: 'وی‌آی‌پی پرو',
-        price: 199_000,
-        period: 'ماهانه',
-        buttonText: 'ارتقا به پرو',
-        benefits: ['حذف تمام تبلیغات', 'سه برابر محدودیت روزانه', 'جوایز و ماموریت‌های اختصاصی'],
-        badge: 'حرفه‌ای‌ها',
+        buttonText: 'خرید اشتراک',
+        benefits: ['حذف تمام تبلیغات', 'دو برابر شدن محدودیت‌های روزانه', 'پشتیبانی اولویت‌دار'],
+        badge: '',
         featured: true,
-        order: 2,
+        order: 1,
         active: true
       }
     ],
     vipSummary: {
       enabled: true,
-      customNote: 'با فعال‌سازی VIP تبلیغات حذف می‌شود و محدودیت‌های روزانه افزایش می‌یابد.',
-      perks: [],
-      trialDays: 3,
-      slots: 150,
+      customNote: 'اشتراک VIP فقط یک پلن دارد؛ با فعال‌سازی، تبلیغات حذف و محدودیت‌های روزانه افزایش می‌یابد.',
+      perks: ['حذف تبلیغات', 'دو برابر شدن محدودیت‌ها', 'پشتیبانی اولویت‌دار'],
+      trialDays: 0,
+      slots: 0,
       autoRenew: true,
       autoApprove: true,
       billingCycle: 'monthly'

--- a/server/src/services/publicContent.js
+++ b/server/src/services/publicContent.js
@@ -386,8 +386,7 @@ const DEFAULT_REMOTE_CONFIG = {
       { id: 'c3000', amount: 3000, bonus: 25, priceToman: 899_000, priceCents: 2999 }
     ],
     vip: {
-      lite: { id: 'vip_lite', priceCents: 299 },
-      pro: { id: 'vip_pro', priceCents: 599 }
+      standard: { id: 'vip_standard', priceCents: 499 }
     },
     keys: [
       { id: 'k1', amount: 1, priceGame: 30, label: 'بسته کوچک' },

--- a/server/test/paymentsController.test.js
+++ b/server/test/paymentsController.test.js
@@ -170,8 +170,8 @@ test('createInternalPayment activates VIP subscription and records payment', asy
     return { ...data, _id: 'txn_vip_success' };
   };
 
-  const vipTier = findVipTier('lite');
-  assert.ok(vipTier, 'expected lite tier to be defined in fallback config');
+  const vipTier = findVipTier('standard');
+  assert.ok(vipTier, 'expected standard tier to be defined in fallback config');
 
   const currentExpiry = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
   const user = {
@@ -185,7 +185,7 @@ test('createInternalPayment activates VIP subscription and records payment', asy
   };
 
   const req = {
-    body: { idempotencyKey: 'idem-5', type: 'vip', tier: 'lite' },
+    body: { idempotencyKey: 'idem-5', type: 'vip', tier: 'standard' },
     user,
   };
   const res = createMockRes();


### PR DESCRIPTION
## Summary
- add a dedicated VIP purchase card in the store and wire it to the single remaining subscription
- update VIP rendering logic, remote config defaults, and server fallbacks to expose only one standard plan
- streamline the admin panel’s VIP controls so the single plan is easier to edit and adjust tests to the new tier

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d789dbd4dc8326999215b74dbcab4a