### PR TITLE
Remove content team attribution from quiz author badge

### DIFF
--- a/Iquiz-assets/src/features/quiz/engine.js
+++ b/Iquiz-assets/src/features/quiz/engine.js
@@ -211,7 +211,12 @@ export function renderQuestionUI(q) {
     if (authorLabelEl) {
       authorLabelEl.textContent = sourceKey === 'community'
         ? 'پیشنهاد جامعه آیکوئیز'
-        : 'منتشر شده توسط تیم محتوا';
+        : '';
+      if (!authorLabelEl.textContent) {
+        authorLabelEl.classList.add('hidden');
+      } else {
+        authorLabelEl.classList.remove('hidden');
+      }
     }
     const authorIconEl = authorWrapper.querySelector('[data-author-icon]');
     if (authorIconEl) {


### PR DESCRIPTION
## Summary
- hide the "published by content team" label when questions are not community sourced

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d79be7726c8326af601f8d1746be0c