### PR TITLE
Remove group battle card from group selection

### DIFF
--- a/Iquiz-assets/src/app/bootstrap.js
+++ b/Iquiz-assets/src/app/bootstrap.js
@@ -5627,8 +5627,6 @@ function renderGroupSelect() {
       list.appendChild(card);
     });
   }
-
-  renderGroupBattleCard(list, userGroup);
 }
 
 


### PR DESCRIPTION
## Summary
- remove rendering of the group battle card from the group selection view so only the group list remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79e77afa88326bbee33586688064e