### PR TITLE
Remove duel reminder setup chip from duel section

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -863,7 +863,6 @@
               <p class="text-sm opacity-90 leading-7">پس از دعوت یا پذیرش نبرد، برای هر راند حداکثر ۲۴ ساعت فرصت داری. در صورت عدم شرکت در این بازه، سیستم به شکل خودکار نتیجه را با باخت به نام تو ثبت می‌کند.</p>
               <div class="flex flex-wrap gap-2 text-xs opacity-90">
                 <span class="chip"><i class="fas fa-bell ml-1"></i>اعلان‌ها را فعال نگه دار</span>
-                <span class="chip"><i class="fas fa-calendar-check ml-1"></i>یادآور برای خود تنظیم کن</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the self-reminder chip from the duel countdown banner
- keep only the notification activation chip in the duel guidance area

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a0bdb3bc83268b16a63f0ffd19bd