### PR TITLE
Include recent question IDs in backfill exclusion

### DIFF
--- a/server/src/services/questionService.js
+++ b/server/src/services/questionService.js
@@ -313,7 +313,13 @@ async function getQuestions(params = {}) {
 
   if (items.length < countRequested) {
     const missing = countRequested - items.length;
-    const excludeObjectIds = Array.from(seenIds)
+    const excludeIdsSet = new Set(seenIds);
+    for (const recentId of recentObjectIds) {
+      if (!recentId) continue;
+      excludeIdsSet.add(String(recentId));
+    }
+
+    const excludeObjectIds = Array.from(excludeIdsSet)
       .map((id) => toObjectId(id))
       .filter((id) => id);
     const backfillQuery = cloneQuery(baseQuery);


### PR DESCRIPTION
## Summary
- expand the exclusion set for backfill queries to cover both already selected questions and the user's recent history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e234085c83269ad4c967f16ab702