### PR TITLE
Fix IQuiz bot asset paths

### DIFF
--- a/IQuiz-bot.html
+++ b/IQuiz-bot.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-  <link rel="stylesheet" href="Iquiz-assets/style.css" />
+  <link rel="stylesheet" href="/Iquiz-assets/style.css" />
   <meta name="theme-color" content="#3b82f6" />
 
 </head>
@@ -1792,7 +1792,7 @@
   <!-- Confetti -->
   <canvas id="confetti" class="confetti"></canvas>
   
-<script type="module" src="./Iquiz-assets/main.js" defer></script>
+<script type="module" src="/Iquiz-assets/main.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point local stylesheet link in IQuiz-bot.html to the absolute /Iquiz-assets path
- update module script reference to load from the same absolute assets directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0bb5072b48326a6a8d34de6041328