### PR TITLE
Update admin panel API endpoints and auth handling

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -4490,7 +4490,7 @@
     </div>
   </div>
 
-<script src="./Admin-Panel.js" defer></script>
+<script src="./Admin-Panel.js?v=1736380800" defer></script>
 
 
 


### PR DESCRIPTION
## Summary
- point the admin panel API base URL and province fetches at the /admin/api routes
- ensure the shared API helper adds bearer tokens automatically and normalizes dashboard stats responses
- refresh the admin panel script include with a new cache-busting query string

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e370499b688326b5c967194041413a