### PR TITLE
Persist admin coin pricing configuration

### DIFF
--- a/Admin-Panel.html
+++ b/Admin-Panel.html
@@ -3803,7 +3803,7 @@
                       </div>
                       <div>
                         <label class="block text-xs text-white/60 mb-1">قیمت (تومان)</label>
-                        <input type="number" min="1000" step="1000" class="form-input text-sm" data-coin-field="priceToman" value="59000">
+                        <input type="number" min="1000" step="1000" class="form-input text-sm" data-coin-field="priceToman">
                       </div>
                       <div>
                         <label class="block text-xs text-white/60 mb-1">روش پرداخت</label>


### PR DESCRIPTION
## Summary
- ensure coin package collection records `priceToman`, uses helpers for numeric parsing, and populates UI fields from stored pricing
- merge updated coin pricing into `shop.pricing` when saving settings, cache the latest server snapshot, and surface toast-only handling for 401 responses
- remove hardcoded coin price defaults from the admin template

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e521eea780832698670547ec365f1e