### PR TITLE
Refactor public fallbacks

### DIFF
--- a/server/src/utils/fallbacks.js
+++ b/server/src/utils/fallbacks.js
@@ -1,0 +1,13 @@
+module.exports = {
+  getFallbackCategories: () => ([
+    { id: 'general', name: 'عمومی' },
+    { id: 'science', name: 'علمی' },
+    { id: 'sports', name: 'ورزشی' }
+  ]),
+  getFallbackProvinces: () => ([
+    { id: 1, name: 'تهران' },
+    { id: 2, name: 'اصفهان' },
+    { id: 3, name: 'فارس' }
+  ]),
+  getFallbackConfig: () => ({ ok: true })
+};


### PR DESCRIPTION
## Summary
- move public route fallback helpers to a dedicated utils module
- normalize category and province endpoints to reuse the new fallbacks when database data is missing

## Testing
- node -c server/src/routes/public.routes.js

------
https://chatgpt.com/codex/tasks/task_e_68e61b2f80888326a877f671cd7f4e44