### PR TITLE
Fix subscription me route

### DIFF
--- a/server/src/routes/subscription.routes.js
+++ b/server/src/routes/subscription.routes.js
@@ -3,5 +3,6 @@ const { protect } = require('../middleware/auth');
 const subscriptionController = require('../controllers/subscription.controller');
 
 router.get('/', protect, subscriptionController.getSubscriptionStatus);
+router.get('/me', protect, subscriptionController.getSubscriptionStatus);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add an authenticated /api/subscription/me endpoint that matches the base subscription status response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63b1b950883269da40e46f17c3282