### PR TITLE
Document subscription route mounting

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -101,6 +101,7 @@ app.use('/api/public', require('./routes/public.routes'));
 app.use('/api/jservice', jserviceRoutes);
 app.use('/api', aiRoutes);
 app.use('/api/wallet', require('./routes/wallet.routes'));
+// Mount subscription routes directly without rewriting the path so /api/subscription/* stays intact.
 app.use('/api/subscription', require('./routes/subscription.routes'));
 app.use('/api/payments', require('./routes/payments.routes'));
 app.use('/payments', require('./routes/payments-public.routes'));


### PR DESCRIPTION
## Summary
- clarify that the subscription router is mounted without any URL rewriting to keep /api/subscription endpoints reachable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63d72bea48326932bb83a3517beb3