### PR TITLE
Fix IRR formatter export

### DIFF
--- a/Iquiz-assets/src/utils/format.js
+++ b/Iquiz-assets/src/utils/format.js
@@ -8,7 +8,11 @@ export const faNum = (value) => {
 export const formatIRR = (value) => {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return '—';
-  return numeric.toLocaleString('fa-IR');
+
+  // IRR values are always displayed without fractional parts. Using faNum keeps
+  // the behaviour consistent with the other helpers in this module while
+  // ensuring we always return Persian digits.
+  return faNum(Math.trunc(numeric));
 };
 
 export const faDecimal = (value, digits = 1) => {


### PR DESCRIPTION
## Summary
- ensure the IRR formatting helper returns a consistent Persian-number representation without fractional parts
- document the intent of the formatter to avoid missing exports at build time

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e6861e7e788326889c6f61d9811a21